### PR TITLE
De-duplicate repeated content in chapter 7 (AI in RE)

### DIFF
--- a/docs/03-Clean-Start/01-duration-terms.adoc
+++ b/docs/03-Clean-Start/01-duration-terms.adoc
@@ -17,7 +17,7 @@ Dazu gehören vor allem:
 
 === Begriffe und Konzepte
 
-Vision, Business Goals, Stakeholder, Scope, Kontext, SMART, PAM
+Vision, Business Goals, Stakeholder, Scope, Kontext, SMART, PAM (Purpose, Advantage, Metric)
 
 // end::DE[]
 
@@ -38,7 +38,7 @@ These mainly include:
 
 === Terms and concepts
 
-Vision, Business Goals, Stakeholders, Scope, Context, SMART, PAM
+Vision, Business Goals, Stakeholders, Scope, Context, SMART, PAM (Purpose, Advantage, Metric)
 
 // end::EN[]
 

--- a/docs/07-AI-in-RE/01-duration-terms.adoc
+++ b/docs/07-AI-in-RE/01-duration-terms.adoc
@@ -12,7 +12,7 @@
 
 Künstliche Intelligenz, insbesondere Large Language Models (LLMs), wird zunehmend zur Unterstützung des Requirements Engineering eingesetzt. Da LLMs Werkzeuge für Sprache und Text sind, passen ihre Stärken – Text erzeugen, umformen, zusammenfassen und vergleichen – zu vielen Aktivitäten des Requirements Engineering, von der Vorbereitung der Erhebung bis zum Entwerfen, Analysieren und Konsolidieren von Anforderungen.
 
-Zugleich enthalten plausible Ergebnisse von KI möglicherweise Fehler: LLMs arbeiten nichtdeterministisch, können halluzinieren, es fehlt ihnen an Domänen- und implizitem Wissen, und sie können Bias widerspiegeln; zudem enthalten Anforderungen oft vertrauliches Firmenwissen, das nicht mit beliebigen Modellen geteilt werden darf. Requirements Engineering bleibt daher im Wesentlichen eine kommunikative Tätigkeit mit Stakeholdern: KI kann solche Gespräche vor- und nachbereiten, aber nicht ersetzen, und die Verantwortung für die entstehenden Anforderungen bleibt bei Menschen (_Human-in-the-Loop_).
+Zugleich haben LLMs Grenzen und Risiken, die Requirements Engineers kennen und einschätzen können müssen (vgl. <<LZ-7-1>> und <<LZ-7-3>>). Requirements Engineering bleibt daher im Wesentlichen eine kommunikative Tätigkeit mit Stakeholdern: KI kann solche Gespräche vor- und nachbereiten, aber nicht ersetzen, und die Verantwortung für die entstehenden Anforderungen bleibt bei Menschen (_Human-in-the-Loop_).
 
 Dieses Kapitel führt in die Potenziale und Grenzen von LLMs für die Anforderungsarbeit ein, zeigt konkrete Einsatzszenarien entlang der in früheren Kapiteln behandelten Aktivitäten und erläutert, wie sich KI-Ergebnisse prüfen und kritisch bewerten lassen.
 
@@ -30,7 +30,7 @@ Large Language Model (LLM), Generative KI, Prompt, Kontext, Halluzination, Bias,
 
 Artificial intelligence, in particular large language models (LLMs), is increasingly used to support requirements engineering. Because LLMs are tools for language and text, their strengths - generating, transforming, summarizing and comparing text - match many requirements engineering activities, from preparing elicitation to drafting, analysing and consolidating requirements.
 
-At the same time, plausible AI output may contain errors: LLMs are non-deterministic, can hallucinate, lack domain and tacit knowledge, and reflect bias; in addition, requirements often contain confidential company knowledge that must not be shared with arbitrary models. Requirements engineering therefore remains essentially a communicative activity with stakeholders: AI can prepare and follow up on such conversations, but it cannot replace them, and humans stay responsible for the resulting requirements (_human-in-the-loop_).
+At the same time, LLMs have inherent limitations and risks that requirements engineers need to know and assess (see <<LG-7-1>> and <<LG-7-3>>). Requirements engineering therefore remains essentially a communicative activity with stakeholders: AI can prepare and follow up on such conversations, but it cannot replace them, and humans stay responsible for the resulting requirements (_human-in-the-loop_).
 
 This chapter introduces the potential and the limitations of LLMs for requirements work, shows concrete use cases along the requirements activities covered in earlier chapters, and explains how to check and critically assess AI-generated results.
 

--- a/docs/07-AI-in-RE/02-learning-goals.adoc
+++ b/docs/07-AI-in-RE/02-learning-goals.adoc
@@ -13,7 +13,7 @@
 
 * Wissen, dass LLMs Werkzeuge für Sprache und Text sind. Ihre Stärken (Text erzeugen, umformen, zusammenfassen und vergleichen) passen zu vielen Aktivitäten des Requirements Engineering.
 * Verstehen, dass LLMs nichtdeterministisch arbeiten: Derselbe Prompt kann unterschiedliche Ergebnisse liefern. Ergebnisse sind daher nicht ohne Weiteres reproduzierbar, was bei wiederholten Prüfungen, Reviews und Baselines berücksichtigt werden muss.
-* Verstehen, dass plausible Ergebnisse nicht unbedingt korrekt sind. Halluzinationen, fehlendes Domänenwissen und fehlendes implizites Wissen begrenzen die Verlässlichkeit von LLM-Ergebnissen.
+* Verstehen, dass plausible Ergebnisse nicht unbedingt korrekt sind. Halluzinationen, fehlendes Domänen- und implizites Wissen sowie Bias begrenzen die Verlässlichkeit von LLM-Ergebnissen.
 * Wissen, dass eigener Kontext (mitgegebene Dokumente, RAG, Werkzeug-Integration) fehlendes Domänenwissen mildert und Halluzinationen reduziert, aber nicht beseitigt.
 * Verstehen, dass Requirements Engineering Kommunikation und Aushandlung mit Stakeholdern bleibt. KI kann solche Gespräche vorbereiten und nachbereiten, aber nicht ersetzen.
 * Wissen, dass die Verantwortung für Anforderungen bei Menschen bleibt (Human-in-the-Loop, verpflichtende Reviews)
@@ -26,13 +26,13 @@
 * Wissen, dass LLMs Entwürfe für Stories, Use Cases, Qualitätsszenarien und Gherkin-Beispiele erstellen können (vgl. Kapitel 5 und 6) und Anforderungen zwischen Abstraktionsebenen und Notationen umformulieren können
 * Wissen, dass LLMs beim Identifizieren architekturrelevanter Anforderungen (ASRs) und beim Konkretisieren vager Qualitätsziele zu Qualitätsszenarien unterstützen können (vgl. Kapitel 5)
 * Wissen, dass LLMs große Anforderungsmengen zusammenfassen sowie Glossare und Begriffe auf Konsistenz prüfen können
-* Verstehen, dass KI in all diesen Einsatzszenarien Entwürfe, Kritik oder Übersetzungen liefert. Entscheidungen treffen weiterhin Menschen.
+* Verstehen, dass KI in all diesen Einsatzszenarien Entwürfe, Kritik oder Übersetzungen liefert, Entscheidungen aber weiterhin bei Menschen liegen (vgl. <<LZ-7-1>>).
 
 [[LZ-7-3]]
 ==== LZ 7-3: KI-Ergebnisse prüfen und kritisch bewerten
 
 * Wissen, wie sich KI-Ergebnisse systematisch prüfen lassen, etwa gegen Aussagen der Stakeholder, das Glossar und bestehende Anforderungen
-* Typische Risiken beim Einsatz von LLMs kennen, etwa Halluzinationen, Bias und Scheingenauigkeit
+* Wissen, dass die in <<LZ-7-1>> genannten Risiken (z. B. Halluzinationen, Bias) beim Prüfen von KI-Ergebnissen besonders zu beachten sind, ergänzt um Scheingenauigkeit als weiteres Risiko
 * Verstehen, dass LLMs den Engpass vom Schreiben zum Prüfen verschieben: Sie erzeugen mühelos viel plausiblen Text, aber Menge ist nicht Qualität – der Prüfaufwand wächst.
 * Verstehen, dass Anforderungen oft vertrauliches Firmenwissen enthalten (Vertraulichkeit, Datenschutz, geistiges Eigentum) und daher nicht jedes Modell damit arbeiten darf
 * Wissen, dass es neben Vertraulichkeit weitere organisatorische und regulatorische Rahmenbedingungen gibt, etwa Firmen-Policies zu freigegebenen Werkzeugen und regulatorische Vorgaben wie den EU AI Act.
@@ -49,7 +49,7 @@
 
 * Know that LLMs are tools for language and text. Their strengths (generating, transforming, summarizing and comparing text) match many activities in requirements engineering.
 * Understand that LLMs are non-deterministic: the same prompt can produce different results. Results are therefore not readily reproducible, which must be taken into account for repeated checks, reviews, and baselines.
-* Understand that plausible output is not necessarily correct. Hallucinations, missing domain knowledge and missing tacit knowledge limit the reliability of LLM results.
+* Understand that plausible output is not necessarily correct. Hallucinations, missing domain and tacit knowledge, and bias limit the reliability of LLM results.
 * Know that providing custom context (supplied documents, RAG, tool integration) mitigates missing domain knowledge and reduces hallucinations, but does not eliminate them.
 * Understand that requirements engineering remains communication and negotiation with stakeholders. AI can prepare and follow up on such conversations, but cannot replace them.
 * Know that humans remain responsible for requirements (human-in-the-loop, mandatory reviews)
@@ -62,13 +62,13 @@
 * Know that LLMs can draft stories, use cases, quality scenarios and Gherkin examples (see sections 5 and 6), and can rephrase requirements between levels of abstraction and notations
 * Know that LLMs can support identifying architecturally significant requirements (ASRs) and refining vague quality goals into quality scenarios (see chapter 5)
 * Know that LLMs can summarize large sets of requirements and check glossaries and terminology for consistency
-* Understand that in all these use cases AI delivers drafts, critique or translations. Decisions are still made by humans.
+* Understand that in all these use cases AI delivers drafts, critique or translations, while decisions remain with humans (see <<LG-7-1>>).
 
 [[LG-7-3]]
 ==== LG 7-3: Checking and critically assessing AI-generated results
 
 * Know how to check AI results systematically, e.g. against statements of stakeholders, the glossary and existing requirements
-* Know typical risks of using LLMs, like hallucinations, bias and false precision
+* Know that the risks named in <<LG-7-1>> (e.g. hallucinations, bias) are particularly relevant when checking results, in addition to false precision as a further risk
 * Understand that LLMs shift the bottleneck from writing to checking: they effortlessly produce large amounts of plausible text, but quantity is not quality – the review effort grows.
 * Understand that requirements often contain confidential company knowledge (confidentiality, data protection, intellectual property), so not every model may process them
 * Know that beyond confidentiality there are further organizational and regulatory constraints, such as company policies on approved tools and regulations like the EU AI Act.


### PR DESCRIPTION
## Summary
- Fixes #79: chapter 7 restated several points multiple times (hallucinations, confidentiality/data protection, human-in-the-loop, "plausible != correct") across the chapter intro and LG 7-1/7-2/7-3.
- Keeps the clean split proposed in the issue: LG 7-1 = potential + limitations, LG 7-2 = use cases, LG 7-3 = checking/assessing results. Each point is now stated once in its primary LG and cross-referenced elsewhere instead of restated.
- The timing/duration proposal from the issue (revisiting the 60 min weight) is intentionally left untouched, per request.

## Test plan
- [x] `asciidoctor` build for EN passes with `--failure-level=WARN` (no broken xrefs)
- [x] `asciidoctor` build for DE passes with `--failure-level=WARN` (no broken xrefs)
- [ ] Reviewer sanity-check that the cross-references (LZ-7-1/LG-7-1) still read naturally in context
