### PR TITLE
Add Story Mapping and Impact Mapping references (#75)

### DIFF
--- a/docs/03-Clean-Start/01-duration-terms.adoc
+++ b/docs/03-Clean-Start/01-duration-terms.adoc
@@ -17,7 +17,7 @@ Dazu gehören vor allem:
 
 === Begriffe und Konzepte
 
-Vision, Business Goals, Stakeholder, Scope, Kontext, SMART, PAM (Purpose, Advantage, Metric)
+Vision, Business Goals, Stakeholder, Scope, Kontext, SMART, PAM (Purpose, Advantage, Metric), Impact Mapping, Story Mapping
 
 // end::DE[]
 
@@ -38,7 +38,7 @@ These mainly include:
 
 === Terms and concepts
 
-Vision, Business Goals, Stakeholders, Scope, Context, SMART, PAM (Purpose, Advantage, Metric)
+Vision, Business Goals, Stakeholders, Scope, Context, SMART, PAM (Purpose, Advantage, Metric), Impact Mapping, Story Mapping
 
 // end::EN[]
 

--- a/docs/03-Clean-Start/02-learning-goals.adoc
+++ b/docs/03-Clean-Start/02-learning-goals.adoc
@@ -13,6 +13,7 @@
 
 * Verstehen, dass Visionen oder Business Goals die obersten Anforderungen sind, also jene, die sich (hoffentlich) während eines Projekts nicht ändern <<pichler>>
 * Verstehen, dass Visionen und Ziele quantifiziert und messbar gemacht werden sollten, um Erfolg in Bezug auf Business Value überprüfen zu können
+* Wissen, wie sich Business Goals systematisch mit Impact Mapping <<adzic-impact>> auf Akteure, gewünschte Verhaltensänderungen (Impacts) und konkrete Deliverables herunterbrechen lassen
 
 [[LZ-3-3]]
 ==== LZ 3-3: Verschiedene Möglichkeiten und Notationen, Visionen und Business Goals auszudrücken
@@ -47,6 +48,7 @@ Wissen, dass:
 * Die Bedeutung externer Schnittstellen kennen
 * Verschiedene Ebenen von „extern" unterscheiden (extern zum System, extern zur Geschäftseinheit, extern zum Unternehmen)
 * Verschiedene Möglichkeiten und Notationen kennen, Scope und Kontext auszudrücken, z.B. Kontextdiagramme
+* Story Mapping <<patton>> als Technik kennen, um zunächst die Breite des Scopes (das „Backbone" der Nutzer-Journey) sichtbar zu machen, bevor einzelne Bereiche vertieft werden („Breite vor Tiefe", vgl. <<LZ-4-4>>)
 
 // end::DE[]
 
@@ -63,6 +65,7 @@ Wissen, dass:
 
 * Understand that visions or business goals are your highest level requirements, i.e. those requirements that are (hopefully) not changed during a project <<pichler>>
 * Understand that visions and goals should be quantified and made measurable to be able to check success in terms of business value.
+* Know how to systematically break down business goals using Impact Mapping <<adzic-impact>> into actors, the impacts (behaviour changes) they should deliver, and concrete deliverables
 
 [[LG-3-3]]
 ==== LG 3-3: Different options and notations for expressing visions and business goals
@@ -97,6 +100,7 @@ Know:
 * Know about the importance of external interfaces
 * Distinguish between various levels of externality (external to the system, external to the business unit, external to the enterprise)
 * Know different options and notations for expressing scope and context, i.e. context diagrams
+* Know Story Mapping <<patton>> as a technique to first visualize the breadth of the scope (the "backbone" of the user journey) before going deeper into individual areas ("breadth before depth", see <<LG-4-4>>)
 
 // end::EN[]
 

--- a/docs/04-Functional-Requirements/01-duration-terms.adoc
+++ b/docs/04-Functional-Requirements/01-duration-terms.adoc
@@ -14,7 +14,7 @@ In den letzten Jahrzehnten sind viele Notationen für funktionale Anforderungen 
 
 === Begriffe und Konzepte
 
-Funktionale Anforderungen, Use Case, Epic, Feature, Story, Szenario, Akzeptanzkriterien, Definition of Ready (DoR), INVEST, CCC-Regel
+Funktionale Anforderungen, Use Case, Epic, Feature, Story, Szenario, Akzeptanzkriterien, Definition of Ready (DoR), INVEST, CCC-Regel, Story Mapping
 
 // end::DE[]
 
@@ -32,7 +32,7 @@ Over the last decades many notations have been developed to express functional r
 
 === Terms and concepts
 
-Functional Requirements, Use Case, Epic, Feature, Story, Scenario, Acceptance Criteria, Definition of Ready (DoR), INVEST, CCC-Rule
+Functional Requirements, Use Case, Epic, Feature, Story, Scenario, Acceptance Criteria, Definition of Ready (DoR), INVEST, CCC-Rule, Story Mapping
 
 
 // end::EN[]

--- a/docs/04-Functional-Requirements/02-learning-goals.adoc
+++ b/docs/04-Functional-Requirements/02-learning-goals.adoc
@@ -23,6 +23,7 @@ Verstehen, dass viele unterschiedliche Kriterien zur Zerlegung eines Systems in 
 ==== LZ 4-4: Anforderungen in wertschöpfende Prozesse zerlegen oder gruppieren
 
 * Wissen, dass prozessorientierte Zerlegung (Geschäftsprozesse, Use Cases, Stories, Ereignis-Prozessketten, ...) ein bewährter Ansatz ist, um einige davon früh zu implementieren und andere zurückzustellen – und so früh Business Value zu schaffen
+* Story Mapping <<patton>> als die typische Technik kennen, um Stories über die Nutzer-Journey hinweg anzuordnen und in Releases zu schneiden (vgl. <<LZ-3-6>>)
 * Den ersten Teil von „INVEST" <<wake2003>> verstehen: Funktionale Anforderungen sollten „independent", „negotiable" und „valuable" sein
 
 [[LZ-4-5]]
@@ -97,6 +98,7 @@ Understand that many different criteria can be applied to decompose a system int
 ==== LG 4-4:Decomposing or grouping requirements into value-adding processes
 
 * Know that a process-oriented decomposition (business processes, use cases, stories, event process chains, ...) are a proven approach to allow for early implementation of some of them and postpone others), thus creating early business value.
+* Know Story Mapping <<patton>> as the canonical technique to arrange stories across the user journey and slice them into releases (see <<LG-3-6>>)
 * Understand the first part of "INVEST" <<wake2003>>: functional requirements should be "independent", "negotiable" and "valuable".
 
 [[LG-4-5]]

--- a/docs/08-Prioritization/01-duration-terms.adoc
+++ b/docs/08-Prioritization/01-duration-terms.adoc
@@ -13,7 +13,7 @@ Die zweite Voraussetzung dafür, manche Anforderungen früher als andere umzuset
 
 === Begriffe und Konzepte
 
-Business Value, Risiko, Ranking, Priorisierung, Affinity Estimation, Wall Estimation, Story Points, WSJF, MoSCoW-Priorisierung
+Business Value, Risiko, Ranking, Priorisierung, Affinity Estimation, Wall Estimation, Story Points, WSJF, MoSCoW-Priorisierung, Impact Mapping
 
 // end::DE[]
 
@@ -31,7 +31,7 @@ The other prerequisite for implementing some requirements earlier than others is
 
 === Terms and concepts
 
-Business value, risk, ranking, prioritization, affinity estimation, wall estimation, story points, WSJF, MoSCoW-prioritization
+Business value, risk, ranking, prioritization, affinity estimation, wall estimation, story points, WSJF, MoSCoW-prioritization, Impact Mapping
 
 // end::EN[]
 

--- a/docs/08-Prioritization/02-learning-goals.adoc
+++ b/docs/08-Prioritization/02-learning-goals.adoc
@@ -11,6 +11,7 @@
 Manche interessieren sich für kurzfristigen Umsatz, andere für bessere Kundenzufriedenheit oder schnelle Time-to-Market.
 Wieder andere wollen das Risiko für die restliche Entwicklung reduzieren oder eine Plattform für langfristige Kosteneinsparungen schaffen. <<mcgreal>>
 * Verschiedene Methoden kennen, um Wert auszudrücken, z.B. MoSCoW-Priorisierung <<clegg>> <<moscow>>, definierte Wertebereiche, lineare Sortierung aller Anforderungen, gewichtete Faktorenmethoden, Cost of Delay, ...
+* Impact Mapping <<adzic-impact>> als Technik kennen, um Anforderungen und Deliverables auf ihren Beitrag zu Business Goals zurückzuführen und so zu bewerten (vgl. <<LZ-3-2>>)
 
 
 [[LZ-8-2]]
@@ -43,6 +44,7 @@ Wieder andere wollen das Risiko für die restliche Entwicklung reduzieren oder e
 Some of them may be interested in short turn revenue, others in improvement of customer satisfaction, or quick time-to-market.
 Others might want to reduce the risk for the rest of the development, or create a platform for longer term cost savings. <<mcgreal>>
 * Know different methods for expressing value, e.g. MoSCoW-prioritization <<clegg>> <<moscow>>, defined ranges of values, linear sorting of all requirements, weighted factor methods, cost of delay, ...
+* Know Impact Mapping <<adzic-impact>> as a technique to trace requirements and deliverables back to their contribution to business goals, and value them accordingly (see <<LG-3-2>>)
 
 
 [[LG-8-2]]

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -17,6 +17,7 @@ This section contains references that are cited in the curriculum.
 
 - [[[adzic-11,Adzic-2011]]] Adzic, Gojko: Specification by Example. Manning, 2011. More info: https://gojko.net/books/specification-by-example/
 - [[[adzic-14,Adzic-2014]]] Adzic, Gojko / Evans, David: Fifty Quick Ideas to Improve Your User Stories. 2014. https://leanpub.com/50quickideas
+- [[[adzic-impact,Adzic-Impact]]] Adzic, Gojko: Impact Mapping: Making a Big Impact with Software Products and Projects. Provoking Thoughts, 2012. https://www.impactmapping.org/
 - [[[ATAM]]] Kazman, Rick: ATAM Method for Architecture Evaluation, (_Architecture Tradeoff Analysis Method_), SEI Technical Report, https://www.sei.cmu.edu/library/atam-method-for-architecture-evaluation/
 
 **B**
@@ -73,6 +74,7 @@ This section contains references that are cited in the curriculum.
 
 **P**
 
+- [[[patton,Patton]]] Patton, Jeff (with Economy, Peter): User Story Mapping: Discover the Whole Story, Build the Right Product. O'Reilly, 2014. https://www.jpattonassociates.com/story-mapping/
 - [[[pichler,Pichler]]] Pichler, R.: Agile Product Management with Scrum: Creating Products that Customers Love. Addison-Wesley, 2010
 
 **Q**


### PR DESCRIPTION
Fixes #75.

**Story Mapping** (Patton) — added to:
- `LZ/LG-3-6` (scope): as the technique to first visualize the breadth of scope ("backbone") before going deeper into individual areas ("breadth before depth")
- `LZ/LG-4-4` (value-adding decomposition): as the canonical technique to arrange stories across the user journey and slice them into releases

Both cross-reference each other.

**Impact Mapping** (Adzic) — added to:
- `LZ/LG-3-2` (business goals): as a technique to systematically break down goals into actors, impacts, and deliverables
- `LZ/LG-8-1` (business value): as a technique to trace requirements/deliverables back to their contribution to business goals

Both cross-reference each other.

**References**: added `patton` (User Story Mapping, O'Reilly 2014) and `adzic-impact` (Impact Mapping, Provoking Thoughts 2012) — kept separate from the existing `adzic-11`/`adzic-14` entries since it's a different book.

**Terms and concepts** updated in chapters 3, 4, and 8 to list the two new techniques.

## Test plan
- [x] `asciidoctor` build for EN passes with `--failure-level=WARN`
- [x] `asciidoctor` build for DE passes with `--failure-level=WARN`
- [x] All new cross-references (`<<LZ-3-6>>`, `<<LG-3-6>>`, `<<LZ-4-4>>`, `<<LG-4-4>>`, `<<LZ-3-2>>`, `<<LG-3-2>>`) resolve correctly