### PR TITLE
Trim estimation-technique enumeration in LG 8-3 (#81)

### DIFF
--- a/docs/08-Prioritization/01-duration-terms.adoc
+++ b/docs/08-Prioritization/01-duration-terms.adoc
@@ -13,7 +13,7 @@ Die zweite Voraussetzung dafür, manche Anforderungen früher als andere umzuset
 
 === Begriffe und Konzepte
 
-Business Value, Risiko, Ranking, Priorisierung, Affinity Estimation, Wall Estimation, Story Points, WSJF, MoSCoW-Priorisierung
+Business Value, Risiko, Ranking, Priorisierung, Affinity Estimation, Story Points, Function Points, WSJF, MoSCoW-Priorisierung
 
 // end::DE[]
 
@@ -31,7 +31,7 @@ The other prerequisite for implementing some requirements earlier than others is
 
 === Terms and concepts
 
-Business value, risk, ranking, prioritization, affinity estimation, wall estimation, story points, WSJF, MoSCoW-prioritization
+Business value, risk, ranking, prioritization, affinity estimation, story points, function points, WSJF, MoSCoW-prioritization
 
 // end::EN[]
 

--- a/docs/08-Prioritization/02-learning-goals.adoc
+++ b/docs/08-Prioritization/02-learning-goals.adoc
@@ -23,11 +23,13 @@ Wieder andere wollen das Risiko für die restliche Entwicklung reduzieren oder e
 [[LZ-8-3]]
 ==== LZ 8-3: Anforderungen schätzen
 
-* Die Notwendigkeit verstehen, Anforderungen zu schätzen – auch als Indikator, größere Anforderungen zu verfeinern und zu zerlegen, wenn sie sich noch nicht gut genug schätzen lassen
-* Den Unterschied zwischen absoluten Schätzungen (in Personentagen, Kosten, ...) und relativen Schätzungen (z.B. Story Points) verstehen
-* Vor- und Nachteile absoluter und relativer Schätzungen kennen
-* Einige relative Schätztechniken kennen, etwa T-Shirt-Sizing und Planning Poker (mit Fibonacci-Werten)
-* Verschiedene Schätztechniken kennen, z.B. Function Points, Story Points, Affinity Estimation, Wall Estimation etc.
+Softwarearchitekt:innen verstehen die Notwendigkeit, Anforderungen zu schätzen, auch als Indikator, größere Anforderungen zu verfeinern und zu zerlegen, wenn sie sich noch nicht gut genug schätzen lassen.
+
+Sie kennen:
+
+* den Unterschied zwischen absoluten Schätzungen (z.B. Personentage, Kosten, oder die klassische, formelbasierte Function-Point-Methode <<function-points>> als Gegenstück zu relativen Verfahren) und relativen Schätzungen (z.B. Story Points).
+* Vor- und Nachteile absoluter und relativer Schätzungen
+* Einige relative Schätztechniken, etwa T-Shirt-Sizing, Affinity Estimation und Planning Poker (mit Fibonacci-Werten)
 
 
 // end::DE[]
@@ -55,11 +57,13 @@ Others might want to reduce the risk for the rest of the development, or create 
 [[LG-8-3]]
 ==== LG 8-3: Estimating requirements
 
-* Understand the need for estimating requirements, also as an indicator to potentially refine and decompose larger requirements when they cannot be estimated well enough yet.
-* Understand the difference between absolute estimates (in person days, costs, ...) versus relative estimates (e.g. story points)
-* Know advantages and disadvantages of absolute and relative estimates
-* Know some relative estimation techniques like T-Shirt-sizing, Planning Poker (with Fibonacci values)
-* Know different estimation techniques, e.g. function points, story points, affinity estimation, wall estimation, etc.
+Software architects understand the need to estimate requirements, also as an indicator to potentially refine and decompose larger requirements when they cannot be estimated well enough yet.
+
+They know:
+
+* the difference between absolute estimates (e.g. person days, costs, or the classical, formula-based function point method <<function-points>> as the counterpart to relative approaches) and relative estimates (e.g. story points).
+* advantages and disadvantages of absolute and relative estimates
+* some relative estimation techniques, e.g. T-Shirt-sizing, affinity estimation and Planning Poker (with Fibonacci values)
 
 
 // end::EN[]

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -33,6 +33,9 @@ This section contains references that are cited in the curriculum.
 
 - [[[dinwiddie,Dinwiddie]]] George Dinwiddie. The Three Amigos - All For One - One For All. Better Software Nov/Dec 2011, vol 13, issue 6, pp 24-27, Online (archived, PDF only): https://www.stickyminds.com/sites/default/files/magazine/file/2013/3971888.pdf
 
+**F**
+
+- [[[function-points,Function-Points]]] Wikipedia: Function Point. https://en.wikipedia.org/wiki/Function_point
 
 **G**
 


### PR DESCRIPTION
Fixes #81.

- Removed the redundant re-listing bullet in LZ/LG-8-3 (story points / affinity / function points were already introduced earlier in the same LG).
- Framed **Function Points** explicitly as the classical, formula-based *absolute* counterpoint to relative estimation, rather than just another item in an enumeration.
- Kept 3 representative relative techniques: T-Shirt-sizing, affinity estimation, Planning Poker.
- Dropped **Wall Estimation** as a niche, redundant variant of affinity estimation.
- Restructured LZ/LG-8-3 into a lead-in sentence + "Sie kennen:"/"They know:" + bullets (DE authored by @gernotstarke, EN follow-up to match).
- Added a lightweight Wikipedia reference (`function-points`) since Function Points wasn't covered by any existing citation in the bibliography.

## Test plan
- [x] `asciidoctor` build for EN passes with `--failure-level=WARN`
- [x] `asciidoctor` build for DE passes with `--failure-level=WARN`
- [x] New `<<function-points>>` cross-reference resolves correctly in both languages