### PR TITLE
Consolidate Three Amigos definition in Ch2 (#82)

### DIFF
--- a/docs/02-Cooperation-between-Roles/01-duration-terms.adoc
+++ b/docs/02-Cooperation-between-Roles/01-duration-terms.adoc
@@ -13,7 +13,7 @@ Architekt:innen sollten außerdem unterschiedliche Wege kennen, Anforderungen fe
 
 === Begriffe und Konzepte
 
-Design Thinking (<<gerstbach>>), Design Sprint (<<banfield>>), Lean Startup (<<ries>>), Three Amigo Sessions (<<dinwiddie>>), Twin-Peaks-Modell (<<nuseibeh>>), Discover-to-Deliver (<<gottesdiener-12>>), Anforderungsdokumentation, Traceability
+Design Thinking (<<gerstbach>>), Design Sprint (<<banfield>>), Lean Startup (<<ries>>), Three Amigo Sessions (<<dinwiddie>>, <<smart-amigo>>), Twin-Peaks-Modell (<<nuseibeh>>), Discover-to-Deliver (<<gottesdiener-12>>), Anforderungsdokumentation, Traceability
 
 // end::DE[]
 
@@ -30,7 +30,7 @@ Architects should also understand different ways to capture and document require
 
 === Terms and concepts
 
-Design Thinking (<<gerstbach>>), Design Sprint (<<banfield>>), Lean Startup (<<ries>>), Three Amigo Sessions (<<dinwiddie>>), Twin Peaks Model (<<nuseibeh>>), Discover-to-Deliver (<<gottesdiener-12>>), Requirements Documentation, Traceability
+Design Thinking (<<gerstbach>>), Design Sprint (<<banfield>>), Lean Startup (<<ries>>), Three Amigo Sessions (<<dinwiddie>>, <<smart-amigo>>), Twin Peaks Model (<<nuseibeh>>), Discover-to-Deliver (<<gottesdiener-12>>), Requirements Documentation, Traceability
 
 
 // end::EN[]

--- a/docs/02-Cooperation-between-Roles/02-learning-goals.adoc
+++ b/docs/02-Cooperation-between-Roles/02-learning-goals.adoc
@@ -13,7 +13,8 @@
 [[LZ-2-2]]
 ==== LZ 2-2: Kooperative Ansätze der Produktentwicklung kennen
 
-* Die Grundideen kooperativer Ansätze kennen, etwa _Discover to Deliver_ <<gottesdiener-12>>, Design Thinking <<gerstbach>>, Lean Startup <<ries>>, Design Sprints <<banfield>>, Twin-Peaks-Modell (<<nuseibeh>>), Three Amigo Sessions (<<dinwiddie>>)
+* Die Grundideen kooperativer Ansätze kennen, etwa _Discover to Deliver_ <<gottesdiener-12>>, Design Thinking <<gerstbach>>, Lean Startup <<ries>>, Design Sprints <<banfield>>, Twin-Peaks-Modell (<<nuseibeh>>)
+* Three Amigo Sessions (TAS) <<dinwiddie>> <<smart-amigo>> als kollaboratives Format kennen: Die drei Rollen „Product Owner" (oder Business Analyst), „Entwickler:in" und „Tester:in" arbeiten darin gemeinsam an der Entdeckung von Anforderungen (vgl. <<LZ-4-11>>, <<LZ-6-2>>)
 * Verstehen, wie sich solche iterativen Ansätze auf größere Systeme skalieren lassen, an denen mehrere – möglicherweise geografisch verteilte – Entwicklungsteams beteiligt sind
 
 
@@ -47,7 +48,8 @@
 [[LG-2-2]]
 ==== LG 2-2: Know cooperative approaches to product development
 
-* Know the basic ideas of cooperative approaches like _Discover to Deliver_ <<gottesdiener-12>>, Design Thinking <<gerstbach>>, Lean Startup <<ries>>, Design Sprints <<banfield>>, Twin Peaks Model (<<nuseibeh>>), Three Amigo Sessions (<<dinwiddie>>)
+* Know the basic ideas of cooperative approaches like _Discover to Deliver_ <<gottesdiener-12>>, Design Thinking <<gerstbach>>, Lean Startup <<ries>>, Design Sprints <<banfield>>, Twin Peaks Model (<<nuseibeh>>)
+* Know Three Amigo Sessions (TAS) <<dinwiddie>> <<smart-amigo>> as a collaborative format: the three roles "product owner" (or business analyst), "developer" and "tester" work together to discover requirements (see <<LG-4-11>>, <<LG-6-2>>)
 * Understand how such iterative approaches can be scaled to larger systems, that involve more than one development team, potentially geographically distributed.
 
 

--- a/docs/04-Functional-Requirements/02-learning-goals.adoc
+++ b/docs/04-Functional-Requirements/02-learning-goals.adoc
@@ -69,7 +69,7 @@ Verstehen, dass viele unterschiedliche Kriterien zur Zerlegung eines Systems in 
 [[LZ-4-11]]
 ==== LZ 4-11: Methoden zur Erhebung funktionaler Anforderungen kennen
 
-* Wissen, dass es viele verschiedene Erhebungstechniken gibt, die Architekt:innen kennen sollten, z.B. Interviews, Fragebögen, Brainstorming-Sitzungen, Three Amigo Sessions <<smart-amigo>>, Knowledge Crunching, Event Storming und viele andere
+* Wissen, dass es viele verschiedene Erhebungstechniken gibt, die Architekt:innen kennen sollten, z.B. Interviews, Fragebögen, Brainstorming-Sitzungen, Three Amigo Sessions (vgl. <<LZ-2-2>>), Knowledge Crunching, Event Storming und viele andere
 * Wissen, wann welche Erhebungstechnik die Kommunikation mit Stakeholdern verbessert
 
 // end::DE[]
@@ -143,7 +143,7 @@ Understand that many different criteria can be applied to decompose a system int
 [[LG-4-11]]
 ==== LG 4-11: Know methods for elicitation of functional requirements
 
-* Know that there are many different elicitation techniques that architects should be aware of, e.g. interviews, questionnaires, brainstorming sessions, three amigo sessions <<smart-amigo>>, knowledge crunching, event storming and many others
+* Know that there are many different elicitation techniques that architects should be aware of, e.g. interviews, questionnaires, brainstorming sessions, Three Amigo Sessions (see <<LG-2-2>>), knowledge crunching, event storming and many others
 * Know when to pick which elicitation technique to improve communication with stakeholders
 
 

--- a/docs/06-Behavior-Driven-Development/02-learning-goals.adoc
+++ b/docs/06-Behavior-Driven-Development/02-learning-goals.adoc
@@ -18,7 +18,7 @@
 ==== LZ 6-2: Prinzipien von Behavior-Driven Development (BDD) verstehen
 
 * Wissen, dass BDD eine kollaborative Praktik zur Entdeckung von Anforderungen ist, die Gespräche über konkrete Beispiele nutzt, um ein gemeinsames Verständnis der Anforderungen aufzubauen
-* Wissen, dass kollaborative Workshops und Diskussionsformate wie Three Amigo Sessions (TAS) <<smart-amigo>> helfen, korrekte Anforderungen zu erhalten. In einer TAS arbeiten die drei Rollen „Product Owner" (oder Business Analyst), „Entwickler:in" und „Tester:in" gemeinsam an der Entdeckung von Anforderungen.
+* Wissen, dass kollaborative Workshops und Diskussionsformate wie Three Amigo Sessions (TAS) helfen, korrekte Anforderungen zu erhalten (vgl. <<LZ-2-2>>)
 * Wissen, dass konkrete Beispiele gut geeignet sind, die Problemdomäne zu erkunden, und eine Grundlage für Akzeptanztests bieten. Example Mapping <<wynne>> hilft, Regeln und offene Fragen zu finden und neue Stories zu identifizieren.
 * Wissen, dass BDD Benutzeranforderungen in Features beschreibt, Features in Stories herunterbricht und die Stories in (ausführbare) Beispiele
 
@@ -52,7 +52,7 @@
 ==== LG 6-2: Understanding principles of Behavior-Driven Development (BDD)
 
 * Know that BDD is a collaborative requirements discovery practice that uses conversations around concrete examples to build a shared understanding of requirements.
-* Know that collaborative workshops and discussion formats, like Three Amigo Sessions (TAS) <<smart-amigo>>, help in getting correct  requirements.  In a TAS, the three roles "product owner" (or business analyse), "developer" and "tester" collaborate in discovering requirements.
+* Know that collaborative workshops and discussion formats, like Three Amigo Sessions (TAS), help in getting correct requirements (see <<LG-2-2>>)
 * Know that concrete examples are a suitable way to help explore the problem domain, and they provide a basis for acceptance tests. Example mapping <<wynne>> helps to find rules, open questions and identify new stories.
 * Know that BDD explains user requirements in features, breaks features down into stories and the stories into (executable) examples.
 


### PR DESCRIPTION
Fixes #82.

Three Amigo Sessions was introduced three separate times (Ch2 terms only, Ch4 LG-4-11, and Ch6 LG-6-2 where it was actually defined).

- **Ch2 (LZ/LG-2-2)** now holds the canonical definition, split into its own bullet: the three roles (Product Owner/Business Analyst, Developer, Tester), citing both `[Dinwiddie]` and `[Smart-Amigo]`.
- **Ch4 (LZ/LG-4-11)**: replaced the citation with a cross-reference back to Ch2; also normalized casing (EN had lowercase "three amigo sessions").
- **Ch6 (LZ/LG-6-2)**: trimmed the duplicated definition to a one-line mention + cross-reference to Ch2. This also fixes the "business analyse" typo the issue flagged, since that whole clause is now superseded by the correct "business analyst" wording in Ch2.

## Test plan
- [x] `asciidoctor` build for EN passes with `--failure-level=WARN`
- [x] `asciidoctor` build for DE passes with `--failure-level=WARN`
- [x] New cross-references (`<<LZ-2-2>>`, `<<LG-2-2>>`, `<<LZ-4-11>>`, `<<LG-4-11>>`, `<<LZ-6-2>>`, `<<LG-6-2>>`) resolve correctly