### PR TITLE
Fix SMART acronym in glossary, cite Doran (#88)

### DIFF
--- a/docs/03-Clean-Start/01-duration-terms.adoc
+++ b/docs/03-Clean-Start/01-duration-terms.adoc
@@ -17,7 +17,7 @@ Dazu gehören vor allem:
 
 === Begriffe und Konzepte
 
-Vision, Business Goals, Stakeholder, Scope, Kontext, SMART, PAM (Purpose, Advantage, Metric)
+Vision, Business Goals, Stakeholder, Scope, Kontext, SMART (Specific, Measurable, Achievable, Relevant, Time-bound), PAM (Purpose, Advantage, Metric)
 
 // end::DE[]
 
@@ -38,7 +38,7 @@ These mainly include:
 
 === Terms and concepts
 
-Vision, Business Goals, Stakeholders, Scope, Context, SMART, PAM (Purpose, Advantage, Metric)
+Vision, Business Goals, Stakeholders, Scope, Context, SMART (Specific, Measurable, Achievable, Relevant, Time-bound), PAM (Purpose, Advantage, Metric)
 
 // end::EN[]
 

--- a/docs/42-glossary/00-glossary.adoc
+++ b/docs/42-glossary/00-glossary.adoc
@@ -77,7 +77,8 @@ Szenario::
 
 Scope:: Der Bereich der Dinge, die bei der Entwicklung eines Systems gestaltet und entworfen werden können.
 
-SMART:: (Akronym für _Specific, Measurable, Achievable, Realistic, Timely_)
+SMART:: (Akronym, siehe <<doran>>, für _Specific, Measurable, Achievable, Relevant, Time-bound_)
+Ursprünglich (Doran, 1981) _Specific, Measurable, Assignable, Realistic, Time-related_ – das „A" steht je nach Quelle für „Achievable" oder „Assignable".
 Ein SMART-Ziel hilft beim Setzen und Spezifizieren von Zielen.
 Es erfüllt alle diese Kriterien, bündelt so die Anstrengungen und erhöht damit die Chance, das Ziel zu erreichen.
 
@@ -173,7 +174,8 @@ Scenario::
 
 Scope:: The range of things that can be shaped and designed when developing a system.
 
-SMART:: (acronym for _Specific, Measurable, Achievable, Realistic, and Timely._)
+SMART:: (acronym, see <<doran>>, for _Specific, Measurable, Achievable, Relevant, Time-bound_)
+Originally (Doran, 1981) _Specific, Measurable, Assignable, Realistic, Time-related_ – the "A" is understood as either "Achievable" or "Assignable" depending on the source.
 A SMART goal helps with setting and specifying goals.
 A SMART goal incorporates all of these criteria to help focus efforts, therefore increasing the chances of achieving that goal.
 

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -32,6 +32,7 @@ This section contains references that are cited in the curriculum.
 **D**
 
 - [[[dinwiddie,Dinwiddie]]] George Dinwiddie. The Three Amigos - All For One - One For All. Better Software Nov/Dec 2011, vol 13, issue 6, pp 24-27, Online (archived, PDF only): https://www.stickyminds.com/sites/default/files/magazine/file/2013/3971888.pdf
+- [[[doran,Doran]]] Doran, G. T.: "There's a S.M.A.R.T. Way to Write Management's Goals and Objectives", Management Review, 70(11), 1981, pp. 35–36.
 
 
 **G**


### PR DESCRIPTION
Fixes #88.

- Replaced the redundant *Achievable, Realistic* with the modern common form *Specific, Measurable, Achievable, Relevant, Time-bound*.
- Noted the original 1981 Doran form used *Assignable* instead of *Achievable* — the "A" is understood either way depending on source.
- Cited Doran (1981) in the glossary entry and added the reference (`doran`) to the bibliography.
- Expanded the SMART acronym at its first occurrence (Ch3 terms and concepts), matching how PAM is already expanded there.

## Test plan
- [x] `asciidoctor` build for EN passes with `--failure-level=WARN`
- [x] `asciidoctor` build for DE passes with `--failure-level=WARN`
- [x] New `<<doran>>` cross-reference resolves correctly in both languages