### PR TITLE
Reword LZ/LG 4-7 documentation-forms sentence (#46)

### DIFF
--- a/docs/04-Functional-Requirements/02-learning-goals.adoc
+++ b/docs/04-Functional-Requirements/02-learning-goals.adoc
@@ -42,7 +42,7 @@ Verstehen, dass viele unterschiedliche Kriterien zur Zerlegung eines Systems in 
 [[LZ-4-7]]
 ==== LZ 4-7: Funktionale Anforderungen dokumentieren
 
-* Verstehen, dass detaillierte funktionale Anforderungen auf verschiedene Arten dokumentiert werden können, z.B. textuell, aber auch in vielen grafischen Formen, die meist mehr Präzision und weniger Interpretationsspielraum bieten, aber teils schwerer zu erstellen und zu verstehen sind als natürlichsprachliche Anforderungen
+* Verstehen, dass detaillierte funktionale Anforderungen auf verschiedene Arten dokumentiert werden können, z.B. textuell, aber auch in vielen grafischen Formen. Grafische Notationen mit klar definierter Syntax und Semantik (z.B. Aktivitätsdiagramme, Zustandsmodelle) können mehr Präzision und weniger Interpretationsspielraum bieten als natürlichsprachliche Anforderungen – informelle oder unscharf definierte Diagramme können hingegen genauso mehrdeutig sein, oder mehrdeutiger. Präzise Notationen erfordern meist auch mehr Fachwissen, um sie zu erstellen und zu verstehen.
 * Grafische Modelle wie Aktivitätsdiagramme, BPMN <<bpmn>>, Informationsmodelle und Zustandsmodelle kennen und wissen, wann welche Notation passt
 
 [[LZ-4-8]]
@@ -116,7 +116,7 @@ Understand that many different criteria can be applied to decompose a system int
 [[LG-4-7]]
 ==== LG 4-7: Documenting functional requirements
 
-* Understand that detailed functional requirements could be documented in various ways, e.g. in textual form but also in many graphical forms that usually add more precision, less interpretability, but a sometimes harder to create and understand compared to plain language requirements
+* Understand that detailed functional requirements can be documented in various ways, e.g. in textual form, but also in many graphical forms. Graphical notations with well-defined syntax and semantics (e.g. activity diagrams, state models) can offer more precision and less room for misinterpretation than natural language — but informal or loosely defined diagrams can be just as ambiguous, or more so. Precise notations typically also require more expert knowledge to create and understand.
 * Know graphical models like activity diagrams, BPMN <<bpmn>>, information models, state models and when to use which notation
 
 [[LG-4-8]]


### PR DESCRIPTION
Fixes #46.

The issue's title references "LG 3-7", but the sentence actually lives at **LZ/LG-4-7** (`04-Functional-Requirements/02-learning-goals.adoc`) — likely stale numbering from before the 2026 restructuring.

Beyond the wording the issue flagged, this also fixes an overgeneralized claim: graphical notations aren't inherently more precise than natural language — only ones with well-defined syntax and semantics are (the LG's own second bullet already lists exactly those: activity diagrams, BPMN, state models). Informal or loosely defined diagrams can be just as ambiguous, or more so.

Changes:
- Fixed the EN grammar bug ("but a sometimes harder to create and understand").
- Fixed the EN mistranslation: "less interpretability" → "less room for misinterpretation" (matching the DE original's "Interpretationsspielraum"), which is what made the sentence read as self-contradictory.
- Scoped the precision claim to notations with well-defined syntax/semantics, and explicitly noted informal diagrams can be just as ambiguous.
- Replaced "expert knowledge to create and understand" language (from the issue's own suggestion) for the previously vague "harder to create and understand".
- Standardized on "natural language requirements" (matching the glossary and the DE original) instead of the one-off "plain language requirements".
- Mirrored the restructuring in DE for consistency between languages.

## Test plan
- [x] `asciidoctor` build for EN passes with `--failure-level=WARN`
- [x] `asciidoctor` build for DE passes with `--failure-level=WARN`