### PR TITLE
Split LZ/LG 3-4 and 3-5 along WHO vs WHAT they value (#85)

### DIFF
--- a/docs/03-Clean-Start/02-learning-goals.adoc
+++ b/docs/03-Clean-Start/02-learning-goals.adoc
@@ -26,6 +26,8 @@
 * Wissen, dass Stakeholder die wichtigsten Quellen für Anforderungen sind
 * Verstehen, dass fehlende Stakeholder fehlende Anforderungen bedeuten können
 * Verstehen, dass Stakeholder auf spezifische, angemessene Weise angesprochen werden müssen
+* Wissen, dass auch die Entwickler:innen Stakeholder sind
+* Wissen, welche Stakeholder häufig vergessen werden (z. B. Legal, Betrieb, Support)
 
 [[LZ-3-5]]
 ==== LZ 3-5: Unterschiedliche Bedürfnisse und Werte verschiedener Stakeholder („Value Propositions")
@@ -34,11 +36,9 @@ Verstehen, dass verschiedene Stakeholder unterschiedliche Bedürfnisse haben und
 
 Wissen, dass:
 
-* auch die Entwickler:innen Stakeholder sind
 * es etablierte Klassifikationsschemata für Stakeholder gibt (z. B. Stakeholder-Matrix)
 * eine priorisierte Stakeholder-Liste hilft, Anforderungen nach Business Value zu priorisieren
 * Architekt:innen Zielkonflikte zwischen den Bedürfnissen der Stakeholder behandeln müssen
-* welche Stakeholder häufig vergessen werden (z. B. Legal, Betrieb, Support)
 
 [[LZ-3-6]]
 ==== LZ 3-6: Scope festlegen und den Kontext des Systems abgrenzen
@@ -76,6 +76,8 @@ Wissen, dass:
 * Know that stakeholders are the most important sources of requirements.
 * Understand that missing stakeholders may mean missing requirements.
 * Understand that architects should be aware that stakeholders need to be addressed in specific, adequate ways.
+* Know that developers are also stakeholders.
+* Know about commonly forgotten stakeholders (e.g. legal, operations, support).
 
 [[LG-3-5]]
 ==== LG 3-5: Different needs and values of different stakeholders  ("value propositions")
@@ -84,11 +86,9 @@ Understand that different stakeholders will have different needs and may differ 
 
 Know:
 
-* that the developers are also stakeholders
 * that there are established classification schemes for stakeholders (e.g. Stakeholder Matrix)
 * that a prioritized stakeholder list helps to prioritize requirements by business value
 * architects have to handle goal conflicts between stakeholder's needs
-* about commonly forgotten stakeholders (e.g. legal, operations, support)
 
 [[LG-3-6]]
 ==== LG 3-6: Scoping and delimiting the context of the system


### PR DESCRIPTION
Fixes #85.

LG 3-4 ("importance of different stakeholders") and LG 3-5 ("different needs and values") overlapped — missing/forgotten stakeholders and "different needs" were both touched in each.

- **LZ/LG-3-4 = WHO**: stakeholder identification, "missing stakeholders = missing requirements", addressing groups adequately, plus (moved from 3-5) "developers are also stakeholders" and commonly forgotten stakeholders (legal, operations, support).
- **LZ/LG-3-5 = WHAT THEY VALUE**: differing needs/value propositions, classification schemes (stakeholder matrix), the prioritized stakeholder list, goal conflicts.

Note: the issue only explicitly called out moving "commonly forgotten stakeholders" to 3-4; I also moved "developers are also stakeholders" there since it's the same kind of WHO-identification fact rather than a WHAT-they-value fact. Happy to leave it in 3-5 if preferred.

## Test plan
- [x] `asciidoctor` build for EN passes with `--failure-level=WARN`
- [x] `asciidoctor` build for DE passes with `--failure-level=WARN`