### PR TITLE
Reduce repetition of just-in-time / just-enough requirements message (#83)

### DIFF
--- a/docs/01-Intro-and-Motivation/02-learning-goals.adoc
+++ b/docs/01-Intro-and-Motivation/02-learning-goals.adoc
@@ -6,7 +6,7 @@
 
 * Wissen, warum gute Anforderungen – insbesondere Qualitätsanforderungen – aus Sicht der Softwarearchitektur notwendig sind
 * Die Kernaufgaben von Softwarearchitekt:innen kennen, zu denen das Klären von Anforderungen und Randbedingungen gehört
-* Das Konzept architekturrelevanter Anforderungen (ASR) verstehen und dass Architekt:innen sich auf diese konzentrieren sollten statt auf Vollständigkeit <<toth>>
+* Das Konzept architekturrelevanter Anforderungen (ASR) kennen <<toth>>, siehe auch Just-in-Time-Anforderungen
 
 [[LZ-1-2]]
 ==== LZ 1-2: Verantwortlichkeiten, Rollen und Kernaktivitäten verstehen
@@ -19,7 +19,7 @@
 ==== LZ 1-3: Den inkrementellen Charakter der Anforderungserhebung verstehen („Just in Time")
 
 * Verstehen, dass Anforderungen und Architektur iterativ entwickelt werden können (und sollten)
-* Verstehen, dass Architekt:innen keine „vollständigen" Anforderungen brauchen, sondern stets gerade genug Anforderungen, um Entwurfsentscheidungen für die nächsten Iterationen zu treffen
+* Wissen, dass Architekt:innen zu jedem Zeitpunkt nur die Anforderungen brauchen, die für anstehende Entwurfsentscheidungen relevant sind (Just-in-Time-Anforderungen, siehe <<LZ-1-1>>)
 * Verstehen, dass Anforderungen iterativ und inkrementell erhoben werden können
 
 // end::DE[]
@@ -30,7 +30,7 @@
 
 * Know the need for good requirements, especially quality requirements seen from the perspective of software architecture
 * Know the key tasks for software architects which include clarifying requirements and constraints
-* Understand the concept of architecturally significant requirements (ASR), and that architects should concentrate on them rather than on completeness <<toth>>
+* Know the concept of architecturally significant requirements (ASR) <<toth>>, see also Just-in-Time Requirements
 
 [[LG-1-2]]
 ==== LG 1-2: Understanding responsibilities, roles and key activities
@@ -43,7 +43,7 @@
 ==== LG 1-3: Understanding the incremental nature of requirements elicitation ("Just in Time")
 
 * Understand that requirements and architecture can (and should) be developed iteratively
-* Understand that architects do not need "complete" requirements, but always just enough requirements to make design decisions for the next iterations
+* Know that architects only need the requirements relevant for the design decisions at hand, at any point in time (Just-in-Time Requirements, see <<LG-1-1>>)
 * Understand that requirements can be elicitated iteratively and incrementally
 
 // end::EN[]

--- a/docs/04-Functional-Requirements/02-learning-goals.adoc
+++ b/docs/04-Functional-Requirements/02-learning-goals.adoc
@@ -12,7 +12,7 @@
 
 * Verstehen, dass (funktionale) Anforderungen auf unterschiedlichen Granularitätsebenen ausgedrückt werden können, von grobgranular bis sehr feingranular
 * Verstehen, dass Architekt:innen für Planung und Schätzung mindestens einen Überblick über grobgranulare funktionale Anforderungen brauchen
-* Wissen, dass nicht jede funktionale Anforderung sofort detailliert werden muss
+* Wissen, dass nicht jede funktionale Anforderung sofort detailliert werden muss (Just-in-Time-Prinzip, vgl. <<LZ-1-3>>)
 
 [[LZ-4-3]]
 ==== LZ 4-3: Kriterien für das Zerlegen grobgranularer funktionaler Anforderungen
@@ -86,7 +86,7 @@ Verstehen, dass viele unterschiedliche Kriterien zur Zerlegung eines Systems in 
 
 * Understand that (functional) requirements can be expressed on different levels of granularity, from coarse grained to very fine grained
 * Understand that architects at least need an overview of coarse grained functional requirements for planning and estimating
-* Know that not every functional requirement has to be detailed immediately
+* Know that not every functional requirement has to be detailed immediately (Just-in-Time principle, see <<LG-1-3>>)
 
 [[LG-4-3]]
 ==== LG 4-3: Criteria for splitting coarse-grained functional requirements

--- a/docs/05-Quality-Requirements/02-learning-goals.adoc
+++ b/docs/05-Quality-Requirements/02-learning-goals.adoc
@@ -14,7 +14,7 @@
 
 * Checklisten für Qualitätsanforderungen und Qualitätsstandards kennen, z.B. <<Q42>>, <<iso25010>>, <<volere,Volere>> (siehe auch <<robertson-24>>)
 * Kategorien von Randbedingungen kennen (organisatorische Randbedingungen, technische Randbedingungen, ...)
-* Verstehen, dass Architekt:innen nicht alle Qualitätsanforderungen und Randbedingungen früh im Projekt benötigen, aber die wichtigsten finden müssen, da diese Architekturtreiber sind und sehr wichtige Architekturentscheidungen beeinflussen
+* Verstehen, dass Architekt:innen nicht alle Qualitätsanforderungen und Randbedingungen früh im Projekt benötigen, aber die wichtigsten finden müssen, da diese Architekturtreiber sind und sehr wichtige Architekturentscheidungen beeinflussen (Just-in-Time-Prinzip, vgl. <<LZ-1-3>>)
 
 [[LZ-5-3]]
 ==== LZ 5-3: Qualitätsanforderungen erheben und spezifizieren
@@ -73,7 +73,7 @@ Ein anderer Weg ist die statistische Beobachtung über die Zeit („schauen, ob 
 
 * Know checklists for quality requirements, quality standards, e.g. <<Q42>>, <<iso25010>>, <<volere,Volere>> (see also <<robertson-24>>)
 * Know categories of constraints (organizational constraints, technical constraints, …)
-* Understand that architects don't need all quality requirements and constraints early in the project, but have to find the most important ones, since they are architecture drivers and will influence very important architectural decision
+* Understand that architects don't need all quality requirements and constraints early in the project, but have to find the most important ones, since they are architecture drivers and will influence very important architectural decisions (Just-in-Time principle, see <<LG-1-3>>)
 
 [[LG-5-3]]
 ==== LG 5-3: Eliciting and specifying quality requirements

--- a/docs/42-glossary/00-glossary.adoc
+++ b/docs/42-glossary/00-glossary.adoc
@@ -17,7 +17,7 @@ Agiles Requirements Engineering:: (angelehnt an IREB): ein kooperativer, iterati
 4. alle anforderungsbezogenen Aktivitäten nach den Prinzipien des agilen Manifests durchführen.
 
 
-ASR:: _Architecturally Significant Requirements_ (architekturrelevante Anforderungen) sind die Teilmenge der Anforderungen mit starkem Einfluss auf Architekturentscheidungen (jene Anforderungen, die Architekturentscheidungen besonders prägen oder beeinflussen).
+ASR:: _Architecturally Significant Requirements_ (architekturrelevante Anforderungen) sind die Teilmenge der Anforderungen mit starkem Einfluss auf Architekturentscheidungen (jene Anforderungen, die Architekturentscheidungen besonders prägen oder beeinflussen). Siehe auch ->Just-in-Time-Anforderungen.
 
 ATDD:: _Acceptance Test Driven Development_
 
@@ -49,6 +49,8 @@ Goals:: -> Business Goal.
 
 GWT:: _Given, When, Then_: Halbstrukturierte Form, Testfälle oder Verhaltensspezifikationen aufzuschreiben.
 Erfunden von Dan North als Teil von ->BDD (Behavior-Driven Development).
+
+Just-in-Time-Anforderungen:: Das Prinzip, dass Architekt:innen keine vollständige Anforderungsmenge im Voraus brauchen, sondern jeweils nur die Anforderungen, die für die anstehenden Entscheidungen relevant sind (siehe ->ASR), erhoben passend zum Bedarf der jeweiligen Iteration.
 
 Kontext:: Der Begriff wird je nach Disziplin unterschiedlich verwendet:
 +
@@ -113,7 +115,7 @@ Agile Requirements Engineering:: (adapted from IREB):  a cooperative, iterative 
 4. performing all requirements related activities according to the principles of the agile manifesto.
 
 
-ASR:: _Architecturally Significant Requirements_ are the subset of requirements that have a strong impact on architectural decisions (those requirements that especially shape or influence architectural decisions.)
+ASR:: _Architecturally Significant Requirements_ are the subset of requirements that have a strong impact on architectural decisions (those requirements that especially shape or influence architectural decisions.) See also ->Just-in-Time Requirements.
 
 ATDD:: _Acceptance Test Driven Development_
 
@@ -153,6 +155,8 @@ Goals::	 -> Business Goal.
 
 GWT:: _Given, When, Then_: Semi-structured way to write down test cases or behavior specifications.
 It was invented by Dan North as part of ->BDD (behavior-driven development).
+
+Just-in-Time Requirements:: The principle that architects do not need a complete set of requirements upfront, only the subset relevant for the decisions at hand (see ->ASR), elicited as needed for each iteration.
 
 LLM:: (_Large Language Model_) An AI model trained on very large amounts of text that processes and generates natural language by predicting, step by step, the most likely next token. Its output is plausible but not necessarily correct. The input it takes into account forms its ->Context.
 


### PR DESCRIPTION
Fixes #83.

The "no complete requirements, just enough, just in time" message was restated near-verbatim across Ch1 intro, LZ/LG-1-1 and LZ/LG-1-3.

- Added a named glossary entry, **Just-in-Time Requirements** / **Just-in-Time-Anforderungen**, cross-referenced with the existing **ASR** entry in both directions.
- **LZ/LG-1-1**: trimmed to the ASR concept plus its `<<toth>>` citation, dropped the "instead of completeness" restatement, points to the glossary term.
- **LZ/LG-1-3**: reworded to keep its unique contribution, dropped the near-verbatim "no complete requirements, just enough" phrasing, cross-references `LZ/LG-1-1`.
- **LZ/LG-4-2** and **LZ/LG-5-2**: kept as-is, since these are legitimate reapplications of the principle in a new, concrete context rather than pure duplication, just added a short cross-reference back to `LZ/LG-1-3` instead of leaving them standing alone.
- The issue also claimed the message appears in "Essentials" (`00b-basics/`), but that section doesn't actually contain it, so nothing was changed there.

## Test plan
- [x] `asciidoctor` build for EN passes with `--failure-level=WARN`
- [x] `asciidoctor` build for DE passes with `--failure-level=WARN`
- [x] New cross-references (`<<LZ-1-1>>`, `<<LG-1-1>>`, `<<LZ-1-3>>`, `<<LG-1-3>>`) resolve correctly