### PR TITLE
Add requirement-phrasing templates (EARS, SOPHIST/Rupp) and ambiguity pitfalls (#74)

### DIFF
--- a/docs/04-Functional-Requirements/02-learning-goals.adoc
+++ b/docs/04-Functional-Requirements/02-learning-goals.adoc
@@ -42,7 +42,7 @@ Verstehen, dass viele unterschiedliche Kriterien zur Zerlegung eines Systems in 
 [[LZ-4-7]]
 ==== LZ 4-7: Funktionale Anforderungen dokumentieren
 
-* Verstehen, dass detaillierte funktionale Anforderungen auf verschiedene Arten dokumentiert werden können, z.B. textuell, aber auch in vielen grafischen Formen, die meist mehr Präzision und weniger Interpretationsspielraum bieten, aber teils schwerer zu erstellen und zu verstehen sind als natürlichsprachliche Anforderungen
+* Verstehen, dass detaillierte funktionale Anforderungen auf verschiedene Arten dokumentiert werden können, z.B. textuell, aber auch in vielen grafischen Formen, die meist mehr Präzision und weniger Interpretationsspielraum bieten, aber teils schwerer zu erstellen und zu verstehen sind als natürlichsprachliche Anforderungen (siehe auch <<LZ-4-12>> für sprachliche Schablonen und Mehrdeutigkeitsfallen bei textuellen Anforderungen)
 * Grafische Modelle wie Aktivitätsdiagramme, BPMN <<bpmn>>, Informationsmodelle und Zustandsmodelle kennen und wissen, wann welche Notation passt
 
 [[LZ-4-8]]
@@ -71,6 +71,13 @@ Verstehen, dass viele unterschiedliche Kriterien zur Zerlegung eines Systems in 
 
 * Wissen, dass es viele verschiedene Erhebungstechniken gibt, die Architekt:innen kennen sollten, z.B. Interviews, Fragebögen, Brainstorming-Sitzungen, Three Amigo Sessions <<smart-amigo>>, Knowledge Crunching, Event Storming und viele andere
 * Wissen, wann welche Erhebungstechnik die Kommunikation mit Stakeholdern verbessert
+
+[[LZ-4-12]]
+==== LZ 4-12: Sprachliche Schablonen und Mehrdeutigkeitsfallen bei textuellen Anforderungen
+
+* Wissen, dass Satzschablonen wie EARS <<mavin-09>> <<mavin-19>> oder die SOPHIST/Rupp-Schablonen <<rupp>> helfen, textuelle Anforderungen syntaktisch einheitlich und präziser zu formulieren
+* Typische sprachliche Mehrdeutigkeitsfallen erkennen, z.B. Weichmacher („benutzerfreundlich", „ausreichend schnell"), Passivkonstruktionen, die Verantwortliche verschleiern, Nominalisierungen, die den eigentlichen Vorgang verstecken, sowie unzureichend qualifizierte Universalquantoren („immer", „alle", „nie")
+* Verstehen, dass Architekt:innen textuelle Anforderungen meist lesen statt selbst zu schreiben, weshalb das Erkennen solcher Mehrdeutigkeiten mindestens so wichtig ist wie das eigene Formulieren
 
 // end::DE[]
 
@@ -116,7 +123,7 @@ Understand that many different criteria can be applied to decompose a system int
 [[LG-4-7]]
 ==== LG 4-7: Documenting functional requirements
 
-* Understand that detailed functional requirements could be documented in various ways, e.g. in textual form but also in many graphical forms that usually add more precision, less interpretability, but a sometimes harder to create and understand compared to plain language requirements
+* Understand that detailed functional requirements could be documented in various ways, e.g. in textual form but also in many graphical forms that usually add more precision, less interpretability, but a sometimes harder to create and understand compared to plain language requirements (see also <<LG-4-12>> for language templates and ambiguity pitfalls in textual requirements)
 * Know graphical models like activity diagrams, BPMN <<bpmn>>, information models, state models and when to use which notation
 
 [[LG-4-8]]
@@ -146,7 +153,12 @@ Understand that many different criteria can be applied to decompose a system int
 * Know that there are many different elicitation techniques that architects should be aware of, e.g. interviews, questionnaires, brainstorming sessions, three amigo sessions <<smart-amigo>>, knowledge crunching, event storming and many others
 * Know when to pick which elicitation technique to improve communication with stakeholders
 
+[[LG-4-12]]
+==== LG 4-12: Language templates and ambiguity pitfalls in textual requirements
 
+* Know that sentence templates such as EARS <<mavin-09>> <<mavin-19>> or the SOPHIST/Rupp templates <<rupp>> help phrase textual requirements in a syntactically consistent and more precise way
+* Recognize common linguistic ambiguity pitfalls, e.g. weak words ("user-friendly", "sufficiently fast"), passive voice that hides who is responsible, nominalisation that hides the actual action, and universal quantifiers ("always", "all", "never") used without qualification
+* Understand that architects mostly read textual requirements written by others rather than writing them, so recognizing such ambiguities is at least as important as phrasing them well
 
 
 // end::EN[]

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -63,6 +63,8 @@ This section contains references that are cited in the curriculum.
 
 **M**
 
+- [[[mavin-09,Mavin-2009]]] Mavin, Alistair / Wilkinson, Philip / Harwood, Adrian / Novak, Mark: Easy Approach to Requirements Syntax (EARS). Proceedings of the 17th IEEE International Requirements Engineering Conference (RE'09), 2009, pp. 317-322. https://doi.org/10.1109/RE.2009.9
+- [[[mavin-19,Mavin-2019]]] Mavin, Alistair / Wilkinson, Philip: Ten Years of EARS. IEEE Software, vol. 36, no. 5, 2019, pp. 10-14. https://doi.org/10.1109/MS.2019.2921164
 - [[[mcgreal,McGreal]]] McGreal, Don / Jocham, Ralph: The Professional Product Owner: Leveraging Scrum as a Competitive Advantage. Addison-Wesley, 2018
 - [[[moscow,MoSCoW]]] Agile Business Consortium: MoSCoW Prioritisation, DSDM Project Framework Handbook. https://www.agilebusiness.org/dsdm-project-framework/moscow-prioritisation.html
 
@@ -84,6 +86,7 @@ This section contains references that are cited in the curriculum.
 - [[[ries,Ries]]] Ries, Eric: The Lean Startup, Crown Business, 2011
 - [[[robertson-24,Robertson-24]]] Robertson,J./Robertson,S.: Mastering the Requirements Process: Getting Requirements Right. Addison Wesley; 4th edition 2024. https://www.volere.org/mastering-the-requirements-process-getting-requirements-right/
 - [[[robertson-19,Robertson-19]]] Robertson, J. /Robertson, S.: Business Analysis Agility. Addison Wesley, 2019
+- [[[rupp,Rupp]]] Rupp, Chris / die SOPHISTen: Requirements-Engineering und -Management: Das Handbuch für Anforderungen in jeder Situation. Carl Hanser Verlag, 7th edition, 2023 (in German)
 
 **S**
 


### PR DESCRIPTION
Closes #74.

Adds a new learning goal, LZ/LG 4-12, introducing EARS and the SOPHIST/Rupp sentence templates for phrasing textual requirements, plus the classic linguistic ambiguity pitfalls (weak words, passive voice, nominalisation, unqualified universal quantifiers).

The goal is explicitly framed as a reading/recognition skill, since architects mostly consume prose requirements written by others rather than authoring them themselves.

Placed at the end of Chapter 4 (LZ/LG-4-12) rather than renumbering into the 4-7 slot, to avoid breaking existing cross-references to LG-4-8 through 4-11 elsewhere in the repo. Cross-referenced from LZ/LG-4-7 instead, satisfying the "near LG 4-7" placement from the issue.

References added:
- Mavin et al., the original 2009 EARS paper (RE'09)
- Mavin & Wilkinson, "Ten Years of EARS", IEEE Software, 2019 — a more modern source, per issue discussion
- Rupp/SOPHIST, *Requirements-Engineering und -Management*, Hanser, 7th edition, 2023

Validated with local asciidoctor builds for both EN and DE tag configurations.

