### PR TITLE
Reword LG 4-4 sentence, fix grammar and stray parenthesis (#45)

### DIFF
--- a/docs/04-Functional-Requirements/02-learning-goals.adoc
+++ b/docs/04-Functional-Requirements/02-learning-goals.adoc
@@ -22,7 +22,7 @@ Verstehen, dass viele unterschiedliche Kriterien zur Zerlegung eines Systems in 
 [[LZ-4-4]]
 ==== LZ 4-4: Anforderungen in wertschöpfende Prozesse zerlegen oder gruppieren
 
-* Wissen, dass prozessorientierte Zerlegung (Geschäftsprozesse, Use Cases, Stories, Ereignis-Prozessketten, ...) ein bewährter Ansatz ist, um einige davon früh zu implementieren und andere zurückzustellen – und so früh Business Value zu schaffen
+* Wissen, dass prozessorientierte Zerlegung (Geschäftsprozesse, Use Cases, Stories, Ereignis-Prozessketten, ...) ein bewährter Ansatz ist, um einige Teile früh zu implementieren und andere zurückzustellen, und so früher Business Value zu schaffen
 * Den ersten Teil von „INVEST" <<wake2003>> verstehen: Funktionale Anforderungen sollten „independent", „negotiable" und „valuable" sein
 
 [[LZ-4-5]]
@@ -96,7 +96,7 @@ Understand that many different criteria can be applied to decompose a system int
 [[LG-4-4]]
 ==== LG 4-4:Decomposing or grouping requirements into value-adding processes
 
-* Know that a process-oriented decomposition (business processes, use cases, stories, event process chains, ...) are a proven approach to allow for early implementation of some of them and postpone others), thus creating early business value.
+* Know that process-oriented decomposition (business processes, use cases, stories, event process chains, ...) is a proven approach to implement some parts early and postpone others, creating business value sooner.
 * Understand the first part of "INVEST" <<wake2003>>: functional requirements should be "independent", "negotiable" and "valuable".
 
 [[LG-4-5]]


### PR DESCRIPTION
Closes #45.

The sentence now lives at LG-4-4 (Chapter 4), not LG-3-4 as in the original issue, since the chapters were renumbered since it was filed.

Fixes the reported subject-verb agreement bug ("a process-oriented decomposition ... are") plus a second, pre-existing bug found while fixing it: an unbalanced closing parenthesis in "postpone others),".

Went with a trimmed version of the suggested rewording, keeping the original "some early, others later" framing rather than importing an explicit business-value slicing criterion into this bullet, since that's already covered by the next bullet's reference to INVEST's "valuable". DE wording updated to match (and dropped an em-dash for a comma while touching the sentence).

Validated with local asciidoctor builds for both EN and DE tag configurations.
