### PR TITLE
Add standard RE literature and missing technique citations (#87)

### DIFF
--- a/docs/08-Prioritization/02-learning-goals.adoc
+++ b/docs/08-Prioritization/02-learning-goals.adoc
@@ -10,13 +10,13 @@
 * Verstehen, dass verschiedene Stakeholder unterschiedlichen Wert in Anforderungen sehen können.
 Manche interessieren sich für kurzfristigen Umsatz, andere für bessere Kundenzufriedenheit oder schnelle Time-to-Market.
 Wieder andere wollen das Risiko für die restliche Entwicklung reduzieren oder eine Plattform für langfristige Kosteneinsparungen schaffen. <<mcgreal>>
-* Verschiedene Methoden kennen, um Wert auszudrücken, z.B. MoSCoW-Priorisierung <<clegg>> <<moscow>>, definierte Wertebereiche, lineare Sortierung aller Anforderungen, gewichtete Faktorenmethoden, Cost of Delay, ...
+* Verschiedene Methoden kennen, um Wert auszudrücken, z.B. MoSCoW-Priorisierung <<clegg>> <<moscow>>, definierte Wertebereiche, lineare Sortierung aller Anforderungen, gewichtete Faktorenmethoden, Cost of Delay <<reinertsen>>, ...
 
 
 [[LZ-8-2]]
 ==== LZ 8-2: Anforderungen nach Business Value ordnen
 
-* Verschiedene Strategien für Ordnung und Priorisierung kennen, z.B. Weighted Shortest Job First (WSJF), Defer Risk, Risk First, ...
+* Verschiedene Strategien für Ordnung und Priorisierung kennen, z.B. Weighted Shortest Job First (WSJF) <<reinertsen>> <<safe>>, Defer Risk, Risk First, ...
 * Wissen, wie man beim Ordnen mit Abhängigkeiten zwischen Anforderungen umgeht
 * Mechanismen kennen, um Anforderungen zu zerlegen und so Abhängigkeiten zu vermeiden
 
@@ -26,8 +26,8 @@ Wieder andere wollen das Risiko für die restliche Entwicklung reduzieren oder e
 * Die Notwendigkeit verstehen, Anforderungen zu schätzen – auch als Indikator, größere Anforderungen zu verfeinern und zu zerlegen, wenn sie sich noch nicht gut genug schätzen lassen
 * Den Unterschied zwischen absoluten Schätzungen (in Personentagen, Kosten, ...) und relativen Schätzungen (z.B. Story Points) verstehen
 * Vor- und Nachteile absoluter und relativer Schätzungen kennen
-* Einige relative Schätztechniken kennen, etwa T-Shirt-Sizing und Planning Poker (mit Fibonacci-Werten)
-* Verschiedene Schätztechniken kennen, z.B. Function Points, Story Points, Affinity Estimation, Wall Estimation etc.
+* Einige relative Schätztechniken kennen, etwa T-Shirt-Sizing und Planning Poker (mit Fibonacci-Werten) <<grenning>> <<cohn>>
+* Verschiedene Schätztechniken kennen, z.B. Function Points <<albrecht>>, Story Points, Affinity Estimation, Wall Estimation etc.
 
 
 // end::DE[]
@@ -42,13 +42,13 @@ Wieder andere wollen das Risiko für die restliche Entwicklung reduzieren oder e
 * Understand that different stakeholders may see different value in requirements.
 Some of them may be interested in short turn revenue, others in improvement of customer satisfaction, or quick time-to-market.
 Others might want to reduce the risk for the rest of the development, or create a platform for longer term cost savings. <<mcgreal>>
-* Know different methods for expressing value, e.g. MoSCoW-prioritization <<clegg>> <<moscow>>, defined ranges of values, linear sorting of all requirements, weighted factor methods, cost of delay, ...
+* Know different methods for expressing value, e.g. MoSCoW-prioritization <<clegg>> <<moscow>>, defined ranges of values, linear sorting of all requirements, weighted factor methods, cost of delay <<reinertsen>>, ...
 
 
 [[LG-8-2]]
 ==== LG 8-2: Ordering requirements by business value
 
-* Know different strategies for ordering and prioritization, e.g. weighted shortest job first (WSJF), defer risk, risk-first ...
+* Know different strategies for ordering and prioritization, e.g. weighted shortest job first (WSJF) <<reinertsen>> <<safe>>, defer risk, risk-first ...
 * Know how to handle dependencies between requirements when ordering requirements
 * Know mechanism to split requirements in order to avoid dependencies
 
@@ -58,8 +58,8 @@ Others might want to reduce the risk for the rest of the development, or create 
 * Understand the need for estimating requirements, also as an indicator to potentially refine and decompose larger requirements when they cannot be estimated well enough yet.
 * Understand the difference between absolute estimates (in person days, costs, ...) versus relative estimates (e.g. story points)
 * Know advantages and disadvantages of absolute and relative estimates
-* Know some relative estimation techniques like T-Shirt-sizing, Planning Poker (with Fibonacci values)
-* Know different estimation techniques, e.g. function points, story points, affinity estimation, wall estimation, etc.
+* Know some relative estimation techniques like T-Shirt-sizing, Planning Poker (with Fibonacci values) <<grenning>> <<cohn>>
+* Know different estimation techniques, e.g. function points <<albrecht>>, story points, affinity estimation, wall estimation, etc.
 
 
 // end::EN[]

--- a/docs/42-glossary/00-glossary.adoc
+++ b/docs/42-glossary/00-glossary.adoc
@@ -39,7 +39,7 @@ Epic:: (angelehnt an IREB): Eine abstrakte Beschreibung eines Stakeholder-Bedür
 
 
 Feature:: Eine Leistung, Service oder Dienst, die ein Stakeholder-Bedürfnis erfüllt.
-Jedes Feature umfasst eine Nutzenhypothese und Akzeptanzkriterien.
+Jedes Feature umfasst eine Nutzenhypothese und Akzeptanzkriterien. <<leffingwell>> <<safe>>
 
 Funktionale Anforderungen:: Eine Anforderung an ein Ergebnis oder Verhalten, das eine Funktion eines Systems (oder einer Komponente oder eines Service) liefern soll.
 
@@ -91,7 +91,7 @@ Use Case:: Eine Beschreibung der möglichen Interaktionen zwischen Akteuren und 
 Use Cases spezifizieren ein System aus Sicht der Nutzer:innen (oder anderer externer Akteure): Jeder Use Case beschreibt Funktionalität, die das System für die beteiligten Akteure bereitstellen muss.
 
 Vision:: Die Vision beschreibt den zukünftigen Zustand der zu entwickelnden Lösung.
-Sie spiegelt die Bedürfnisse von Kund:innen und Stakeholdern wider sowie die Features und Fähigkeiten, die zur Erfüllung dieser Bedürfnisse vorgeschlagen werden.
+Sie spiegelt die Bedürfnisse von Kund:innen und Stakeholdern wider sowie die Features und Fähigkeiten, die zur Erfüllung dieser Bedürfnisse vorgeschlagen werden. <<leffingwell>> <<safe>>
 
 
 // end::DE[]
@@ -143,7 +143,7 @@ Epic:: (adapted from IREB): A high-level, abstract description of a stakeholder 
 
 
 Feature:: A service that fulfills a stakeholder need.
-Each feature includes a benefit hypothesis and acceptance criteria.
+Each feature includes a benefit hypothesis and acceptance criteria. <<leffingwell>> <<safe>>
 
 Functional Requirements:: A requirement concerning a result of behavior that shall be provided by a function of a system (or of a component or service).
 
@@ -187,7 +187,7 @@ Use Case:: A description of the interactions possible between actors and a syste
 Use cases specify a system from a user’s (or other external actor’s) perspective: every use case describes some functionality that the system must provide for the actors involved in the use case.
 
 Vision:: The Vision is a description of the future state of the Solution under development.
-It reflects Customer and stakeholder needs, as well as the Feature and Capabilities, proposed to meet those needs.
+It reflects Customer and stakeholder needs, as well as the Feature and Capabilities, proposed to meet those needs. <<leffingwell>> <<safe>>
 
 
 // end::EN[]

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -17,6 +17,7 @@ This section contains references that are cited in the curriculum.
 
 - [[[adzic-11,Adzic-2011]]] Adzic, Gojko: Specification by Example. Manning, 2011. More info: https://gojko.net/books/specification-by-example/
 - [[[adzic-14,Adzic-2014]]] Adzic, Gojko / Evans, David: Fifty Quick Ideas to Improve Your User Stories. 2014. https://leanpub.com/50quickideas
+- [[[albrecht,Albrecht]]] Albrecht, Allan J.: Measuring Application Development Productivity. Proceedings of the Joint SHARE/GUIDE/IBM Application Development Symposium, 1979, pp. 83-92.
 - [[[ATAM]]] Kazman, Rick: ATAM Method for Architecture Evaluation, (_Architecture Tradeoff Analysis Method_), SEI Technical Report, https://www.sei.cmu.edu/library/atam-method-for-architecture-evaluation/
 
 **B**
@@ -27,6 +28,7 @@ This section contains references that are cited in the curriculum.
 **C**
 
 - [[[clegg,Clegg]]] Dai Clegg and Richard Barker (1994). Case Method Fast-Track: A RAD Approach. Addison-Wesley.
+- [[[cohn,Cohn]]] Cohn, Mike: User Stories Applied: For Agile Software Development. Addison-Wesley, 2004.
 - [[[cucumber,Cucumber]]] Cucumber: BDD testing and executable specifications. https://cucumber.io/
 
 **D**
@@ -39,6 +41,7 @@ This section contains references that are cited in the curriculum.
 - [[[gerstbach,Gerstbach]]] Gerstbach, Ingrid: Design Thinking im Unternehmen: Ein Workbook für die Einführung von Design Thinking, GABAL Verlag, 2016 (in German)
 - [[[gherkin,Gherkin]]] Cucumber: Gherkin Reference. https://cucumber.io/docs/gherkin/reference/
 - [[[gottesdiener-12,Gottesdiener]]] Gottesdiener, Ellen: Discover to Deliver: Agile Product Planning and Analysis, EGB Consulting, 2012
+- [[[grenning,Grenning]]] Grenning, James: Planning Poker or How to avoid Analysis Paralysis while Release Planning. Renaissance Software Consulting, 2002. https://wingman-sw.com/papers/PlanningPoker-v1.1.pdf
 
 **H**
 
@@ -57,9 +60,14 @@ This section contains references that are cited in the curriculum.
 - [[[jacobson,Jacobson]]] Dr. Ivar Jacobson, Ian Spence, Kurt Bittner: Use-Case 2.0: The Guide to Succeeding with Use-Cases. Online: https://www.ivarjacobson.com/publications/white-papers/use-case-20-e-book
 - [[[jeffries-ccc,Jeffries]]] Jeffries, Ron: Essential XP: Card, Conversation, Confirmation, 2001. https://ronjeffries.com/xprog/articles/expcardconversationconfirmation/
 
+**K**
+
+- [[[kotonya-sommerville,Kotonya-Sommerville]]] Kotonya, Gerald / Sommerville, Ian: Requirements Engineering: Processes and Techniques. Wiley, 1998.
+
 **L**
 
 - [[[lawrence,Lawrence]]] Richard Lawrence, Peter Green: The Humanizing Work Guide to Splitting User Stories, https://www.humanizingwork.com/the-humanizing-work-guide-to-splitting-user-stories/
+- [[[leffingwell,Leffingwell]]] Leffingwell, Dean: Agile Software Requirements: Lean Requirements Practices for Teams, Programs, and the Enterprise. Addison-Wesley, 2011.
 
 **M**
 
@@ -81,12 +89,14 @@ This section contains references that are cited in the curriculum.
 
 **R**
 
+- [[[reinertsen,Reinertsen]]] Reinertsen, Donald G.: The Principles of Product Development Flow: Second Generation Lean Product Development. Celeritas Publishing, 2009.
 - [[[ries,Ries]]] Ries, Eric: The Lean Startup, Crown Business, 2011
 - [[[robertson-24,Robertson-24]]] Robertson,J./Robertson,S.: Mastering the Requirements Process: Getting Requirements Right. Addison Wesley; 4th edition 2024. https://www.volere.org/mastering-the-requirements-process-getting-requirements-right/
 - [[[robertson-19,Robertson-19]]] Robertson, J. /Robertson, S.: Business Analysis Agility. Addison Wesley, 2019
 
 **S**
 
+- [[[safe,SAFe]]] Scaled Agile, Inc.: SAFe (Scaled Agile Framework), online. https://scaledagileframework.com/
 - [[[smart-bdd,Smart]]] Smart, J.F. / Molak, J.: BDD in Action: Behavior-Driven Development for the whole software lifecycle. Manning, 2nd edition 2023. https://www.manning.com/books/bdd-in-action-second-edition
 - [[[smart-amigo,Smart-Amigo]]] Smart, J.F.: The Anatomy of a Three Amigo requirements discovery Session. https://johnfergusonsmart.com/three-amigos-requirements-discovery/
 - [[[starke-hruschka-arc42,Starke-Hruschka]]] Starke,G + Hruschka, P: Communicating Software Architectures: lean, effective and painless documentation. Leanpub https://leanpub.com/arc42inpractice
@@ -104,4 +114,5 @@ Carl Hanser Verlag, 4th edition 2025  (in German) - especially for "_Architectur
 
 - [[[wake2003,Wake]]]: Wake, Bill: INVEST in good stories and SMART Tasks,
 xp123.com/Articles/invest-in-good-stories-and-smart-tasks, 2003
+- [[[wiegers-beatty,Wiegers-Beatty]]] Wiegers, Karl / Beatty, Joy: Software Requirements. Microsoft Press, 3rd edition, 2013.
 - [[[wynne,Wynne]]] Wynne, Matt: Introducing Example Mapping: https://cucumber.io/blog/bdd/example-mapping-introduction/


### PR DESCRIPTION
Closes #87.

**Standard literature added:**
- Wiegers & Beatty, *Software Requirements* (3rd ed.)
- Kotonya & Sommerville, *Requirements Engineering: Processes and Techniques*
- Cohn, *User Stories Applied*
- Leffingwell, *Agile Software Requirements*

**Missing technique citations added:**
- Planning Poker (LZ/LG 8-3) → Grenning (the original 2002 paper) and Cohn
- WSJF / Cost of Delay (LZ/LG 8-1, 8-2) → Reinertsen and a new SAFe reference (`safe`)
- Function points (LZ/LG 8-3) → Albrecht (the originating 1979 IBM paper)

**Bonus:** the glossary's Feature and Vision entries use SAFe's definitions essentially verbatim ("benefit hypothesis", "Feature and Capabilities...") but previously cited no source. Added `<<leffingwell>>` and the new `<<safe>>` reference there too.

**Left out intentionally** (per the issue's own overlap note): Patton (*User Story Mapping*), Adzic (*Impact Mapping*), EARS (Mavin et al.) and SOPHIST/Rupp — those are already being added in #75 and #74, to avoid duplicate reference entries.

Validated with local asciidoctor builds for both EN and DE tag configurations.
