### PR TITLE
Add requirements negotiation and conflict resolution (#73)

### DIFF
--- a/docs/03-Clean-Start/02-learning-goals.adoc
+++ b/docs/03-Clean-Start/02-learning-goals.adoc
@@ -37,7 +37,7 @@ Wissen, dass:
 * auch die Entwickler:innen Stakeholder sind
 * es etablierte Klassifikationsschemata für Stakeholder gibt (z. B. Stakeholder-Matrix)
 * eine priorisierte Stakeholder-Liste hilft, Anforderungen nach Business Value zu priorisieren
-* Architekt:innen Zielkonflikte zwischen den Bedürfnissen der Stakeholder behandeln müssen
+* Architekt:innen Zielkonflikte zwischen den Bedürfnissen der Stakeholder erkennen und auflösen müssen (siehe auch <<LZ-8-4>> für Techniken zur Konfliktlösung)
 * welche Stakeholder häufig vergessen werden (z. B. Legal, Betrieb, Support)
 
 [[LZ-3-6]]
@@ -87,7 +87,7 @@ Know:
 * that the developers are also stakeholders
 * that there are established classification schemes for stakeholders (e.g. Stakeholder Matrix)
 * that a prioritized stakeholder list helps to prioritize requirements by business value
-* architects have to handle goal conflicts between stakeholder's needs
+* architects have to identify and resolve goal conflicts between stakeholders' needs (see also <<LG-8-4>> for conflict-resolution techniques)
 * about commonly forgotten stakeholders (e.g. legal, operations, support)
 
 [[LG-3-6]]

--- a/docs/08-Prioritization/02-learning-goals.adoc
+++ b/docs/08-Prioritization/02-learning-goals.adoc
@@ -29,6 +29,13 @@ Wieder andere wollen das Risiko für die restliche Entwicklung reduzieren oder e
 * Einige relative Schätztechniken kennen, etwa T-Shirt-Sizing und Planning Poker (mit Fibonacci-Werten)
 * Verschiedene Schätztechniken kennen, z.B. Function Points, Story Points, Affinity Estimation, Wall Estimation etc.
 
+[[LZ-8-4]]
+==== LZ 8-4: Widersprüchliche Anforderungen erkennen und auflösen
+
+* Verstehen, dass unterschiedliche Stakeholder-Bedürfnisse zu widersprüchlichen Anforderungen führen können, deren Auflösung sich häufig in Architekturentscheidungen niederschlägt
+* Techniken zur Konfliktlösung kennen, z.B. Priorisierung (siehe <<LZ-8-2>>), Trade-off- und Utility-Analyse <<ATAM>>, Eskalation an Entscheidungsträger sowie direkte Verhandlung mit den betroffenen Stakeholdern
+* Wissen, dass sich Architekt:innen bei der Konfliktlösung vor allem auf jene Konflikte konzentrieren sollten, die architekturrelevante Anforderungen (<<LZ-1-1>>) betreffen
+
 
 // end::DE[]
 
@@ -60,6 +67,13 @@ Others might want to reduce the risk for the rest of the development, or create 
 * Know advantages and disadvantages of absolute and relative estimates
 * Know some relative estimation techniques like T-Shirt-sizing, Planning Poker (with Fibonacci values)
 * Know different estimation techniques, e.g. function points, story points, affinity estimation, wall estimation, etc.
+
+[[LG-8-4]]
+==== LG 8-4: Identifying and resolving conflicting requirements
+
+* Understand that different stakeholder needs can lead to conflicting requirements, and that resolving them often translates into architectural decisions
+* Know techniques for conflict resolution, e.g. prioritization (see <<LG-8-2>>), trade-off and utility analysis <<ATAM>>, escalation to decision makers, and direct negotiation with the affected stakeholders
+* Know that architects should focus conflict resolution primarily on conflicts affecting architecturally significant requirements (<<LG-1-1>>)
 
 
 // end::EN[]


### PR DESCRIPTION
Closes #73.

Implements the issue's proposal:
- Extends LZ/LG-3-5 (stakeholder value propositions) so architects must **identify and resolve** goal conflicts, not just "handle" them, cross-referencing a new dedicated learning goal.
- Adds a new **LZ/LG-8-4** in the Prioritization chapter, covering conflict-resolution techniques named in the issue: prioritization, trade-off/utility analysis (via ATAM), escalation, and negotiation with stakeholders. Includes a bullet tying resolution effort to architecturally significant requirements (ASR), per the issue's ASR-focus proposal.

Note: the issue also mentioned a "single word negotiation" in the old Ch7 intro — chapter numbering has since shifted in the 2026 restructuring, and current Ch7 (AI-in-RE) only mentions negotiation in an unrelated "AI cannot replace human negotiation" context, so it was left untouched.

Validated with both EN and DE asciidoctor builds (`--failure-level=WARN`).
