### PR TITLE
De-duplicate acceptance-criteria coverage across LG 4-9, 5-5, and Ch6 (#84)

### DIFF
--- a/docs/04-Functional-Requirements/02-learning-goals.adoc
+++ b/docs/04-Functional-Requirements/02-learning-goals.adoc
@@ -55,8 +55,9 @@ Verstehen, dass viele unterschiedliche Kriterien zur Zerlegung eines Systems in 
 [[LZ-4-9]]
 ==== LZ 4-9: Akzeptanzkriterien für funktionale Anforderungen
 
-* Wissen, dass funktionale Anforderungen Akzeptanzkriterien haben sollten, also Kriterien, mit denen sich (nach der Implementierung) feststellen lässt, ob die Anforderung erfüllt ist
+* Wissen, dass funktionale Anforderungen Akzeptanzkriterien haben sollten, also überprüfbare Kriterien, mit denen sich (nach der Implementierung) eindeutig feststellen lässt, ob die Anforderung erfüllt ist
 * Die „CCC-Regel" <<jeffries-ccc>> verstehen: Card, Conversation, Confirmation. Die Akzeptanzkriterien sind die Grundlage der Confirmation.
+* Verstehen, dass Akzeptanzkriterien die Brücke zu Akzeptanztests bilden und damit die „Definition of Done" der einzelnen Anforderung festlegen
 
 [[LZ-4-10]]
 ==== LZ 4-10: Specification-by-Example verstehen
@@ -129,8 +130,9 @@ Understand that many different criteria can be applied to decompose a system int
 [[LG-4-9]]
 ==== LG 4-9: Acceptance criteria for functional requirements
 
-* Know that functional requirements should have acceptance criteria, i.e. criteria to determine (after implementation) whether the requirement has been fulfilled
+* Know that functional requirements should have acceptance criteria, i.e. testable criteria to unambiguously determine (after implementation) whether the requirement has been fulfilled
 * Understand the "CCC-Rule" <<jeffries-ccc>>: card, conversation, confirmation. The acceptance criteria are the basis for confirmation.
+* Understand that acceptance criteria are the bridge to acceptance tests, effectively forming the per-requirement "definition of done"
 
 [[LG-4-10]]
 ==== LG 4-10: Understanding specification-by-examples

--- a/docs/05-Quality-Requirements/02-learning-goals.adoc
+++ b/docs/05-Quality-Requirements/02-learning-goals.adoc
@@ -39,8 +39,9 @@ Architekt:innen haben verschiedene Möglichkeiten, sie zu präzisieren:
 [[LZ-5-5]]
 ==== LZ 5-5: Akzeptanzkriterien für Qualitätsanforderungen spezifizieren
 
-* Wissen, dass auch Qualitätsanforderungen Akzeptanzkriterien brauchen
+* Wissen, dass auch Qualitätsanforderungen Akzeptanzkriterien brauchen; die grundlegende Definition und die CCC-Regel gelten unverändert (siehe <<LZ-4-9>>)
 * Wissen, dass Akzeptanzkriterien für Qualitätsanforderungen oft über Toleranzen oder Schwellwerte spezifiziert werden können, oder indem Abweichungen für bestimmte Stakeholder erlaubt werden (z.B. erhalten Personen, die kein Englisch sprechen, 20% mehr Zeit für ein Ergebnis)
+* Wissen, dass sich manche Qualitäten nur durch statistische oder operative Beobachtung über die Zeit prüfen lassen statt durch quantifizierte Akzeptanzkriterien (siehe <<LZ-5-7>>)
 * Quellen für Beispiele solcher Akzeptanzkriterien kennen, etwa Q42
 
 
@@ -98,8 +99,9 @@ Architects have various ways of adding precision
 [[LG-5-5]]
 ==== LG 5-5: Specifying acceptance criteria for quality requirements
 
-* Know that also quality requirements need acceptance criteria
+* Know that quality requirements also need acceptance criteria; the basic definition and the CCC rule apply unchanged (see <<LG-4-9>>)
 * Know that acceptance criteria for quality requirements can often be specified by giving tolerances or thresholds, or allowing deviations for certain stakeholders (i.e. person who do not speak English are given 20% more time to achieve a result)
+* Know that some qualities can only be checked via statistical or operational observation over time rather than quantified acceptance criteria (see <<LG-5-7>>)
 * Know sources for examples of such acceptance criteria, like Q42
 
 

--- a/docs/06-Behavior-Driven-Development/02-learning-goals.adoc
+++ b/docs/06-Behavior-Driven-Development/02-learning-goals.adoc
@@ -26,6 +26,7 @@
 [[LZ-6-3]]
 ==== LZ 6-3: Gherkin und Cucumber als Beispiele für BDD kennen
 
+* Verstehen, dass Given-When-Then die ausführbare Form von Akzeptanzkriterien ist (siehe <<LZ-4-9>>): „Given" und „When" beschreiben Ausgangssituation und Aktion, „Then" das erwartete, überprüfbare Ergebnis
 * Die Given-When-Then-Syntax (GWT) kennen, wie Gherkin <<gherkin>> sie vorschlägt
 * Wissen, dass Given-When-Then-basierte Formulierungen von Anforderungen die Testautomatisierung erleichtern
 * Wissen, dass mehrere Werkzeuge existieren, um Given-When-Then-Verhaltensspezifikationen auf den Quellcode des Systems abzubilden (z.B. Cucumber <<cucumber>>, RSpec, SpecFlow, GivWenZen)
@@ -60,6 +61,7 @@
 [[LG-6-3]]
 ==== LG 6-3: Knowing Gherkin and Cucumber as examples for BDD
 
+* Understand that Given-When-Then is the executable form of acceptance criteria (see <<LG-4-9>>): "Given" and "When" describe the starting situation and action, "Then" the expected, checkable outcome.
 * Know the Given-When-Then (GWT) syntax as proposed by Gherkin <<gherkin>>.
 * Know that Given-When-Then based formulations of requirements facilitate test automation.
 * Know that several tools exist to map Given-When-Then behavior specifications to the systems' source code (e.g. Cucumber <<cucumber>>, RSpec, SpecFlow, GivWenZen).


### PR DESCRIPTION
Closes #84.

Implements the issue's proposal:
1. **LG 4-9 is now the canonical definition** of acceptance criteria: sharpened to "testable criteria… unambiguously determine", and added the previously-missing link to acceptance tests / per-requirement "definition of done".
2. **LG 5-5** now keeps only what's different for quality requirements (tolerances/thresholds, statistical/operational checks), cross-referencing LG 4-9 for the base definition/CCC rule and LG 5-7 for the statistical-checks detail, instead of re-defining the concept.
3. **LG 6-3 (Ch6)** now presents Given-When-Then as the *executable form* of acceptance criteria, cross-referencing LG 4-9, instead of reintroducing the concept.

Net: one definition, two deltas, explicit cross-references.

Validated with both EN and DE asciidoctor builds (`--failure-level=WARN`).
