### PR TITLE
Elevate prototyping/mockups and personas/journey maps to techniques (#78)

### DIFF
--- a/docs/03-Clean-Start/01-duration-terms.adoc
+++ b/docs/03-Clean-Start/01-duration-terms.adoc
@@ -17,7 +17,7 @@ Dazu gehören vor allem:
 
 === Begriffe und Konzepte
 
-Vision, Business Goals, Stakeholder, Scope, Kontext, SMART, PAM (Purpose, Advantage, Metric)
+Vision, Business Goals, Stakeholder, Scope, Kontext, SMART, PAM (Purpose, Advantage, Metric), Personas, User-Journey-Maps
 
 // end::DE[]
 
@@ -38,7 +38,7 @@ These mainly include:
 
 === Terms and concepts
 
-Vision, Business Goals, Stakeholders, Scope, Context, SMART, PAM (Purpose, Advantage, Metric)
+Vision, Business Goals, Stakeholders, Scope, Context, SMART, PAM (Purpose, Advantage, Metric), Personas, User Journey Maps
 
 // end::EN[]
 

--- a/docs/03-Clean-Start/02-learning-goals.adoc
+++ b/docs/03-Clean-Start/02-learning-goals.adoc
@@ -26,6 +26,7 @@
 * Wissen, dass Stakeholder die wichtigsten Quellen für Anforderungen sind
 * Verstehen, dass fehlende Stakeholder fehlende Anforderungen bedeuten können
 * Verstehen, dass Stakeholder auf spezifische, angemessene Weise angesprochen werden müssen
+* Personas <<cooper>> und User-Journey-Maps <<kalbach>> als Artefakte kennen, um Stakeholder-Bedürfnisse zu bündeln, im Team greifbar zu machen und über die Zeit hinweg zu visualisieren
 
 [[LZ-3-5]]
 ==== LZ 3-5: Unterschiedliche Bedürfnisse und Werte verschiedener Stakeholder („Value Propositions")
@@ -76,6 +77,7 @@ Wissen, dass:
 * Know that stakeholders are the most important sources of requirements.
 * Understand that missing stakeholders may mean missing requirements.
 * Understand that architects should be aware that stakeholders need to be addressed in specific, adequate ways.
+* Know personas <<cooper>> and user-journey maps <<kalbach>> as artifacts to consolidate stakeholder needs, make them tangible for the team, and visualize them over time
 
 [[LG-3-5]]
 ==== LG 3-5: Different needs and values of different stakeholders  ("value propositions")

--- a/docs/04-Functional-Requirements/01-duration-terms.adoc
+++ b/docs/04-Functional-Requirements/01-duration-terms.adoc
@@ -14,7 +14,7 @@ In den letzten Jahrzehnten sind viele Notationen für funktionale Anforderungen 
 
 === Begriffe und Konzepte
 
-Funktionale Anforderungen, Use Case, Epic, Feature, Story, Szenario, Akzeptanzkriterien, Definition of Ready (DoR), INVEST, CCC-Regel
+Funktionale Anforderungen, Use Case, Epic, Feature, Story, Szenario, Akzeptanzkriterien, Definition of Ready (DoR), INVEST, CCC-Regel, Prototypen, Mockups
 
 // end::DE[]
 
@@ -32,7 +32,7 @@ Over the last decades many notations have been developed to express functional r
 
 === Terms and concepts
 
-Functional Requirements, Use Case, Epic, Feature, Story, Scenario, Acceptance Criteria, Definition of Ready (DoR), INVEST, CCC-Rule
+Functional Requirements, Use Case, Epic, Feature, Story, Scenario, Acceptance Criteria, Definition of Ready (DoR), INVEST, CCC-Rule, Prototypes, Mockups
 
 
 // end::EN[]

--- a/docs/04-Functional-Requirements/02-learning-goals.adoc
+++ b/docs/04-Functional-Requirements/02-learning-goals.adoc
@@ -70,6 +70,7 @@ Verstehen, dass viele unterschiedliche Kriterien zur Zerlegung eines Systems in 
 ==== LZ 4-11: Methoden zur Erhebung funktionaler Anforderungen kennen
 
 * Wissen, dass es viele verschiedene Erhebungstechniken gibt, die Architekt:innen kennen sollten, z.B. Interviews, Fragebögen, Brainstorming-Sitzungen, Three Amigo Sessions <<smart-amigo>>, Knowledge Crunching, Event Storming und viele andere
+* Prototypen und Mockups als Erhebungs- und Validierungstechnik kennen, besonders für UI-/UX-nahe Anforderungen: Nutzer:innen reagieren oft konkreter auf ein sichtbares Artefakt als auf eine abstrakte Beschreibung <<snyder>>
 * Wissen, wann welche Erhebungstechnik die Kommunikation mit Stakeholdern verbessert
 
 // end::DE[]
@@ -144,6 +145,7 @@ Understand that many different criteria can be applied to decompose a system int
 ==== LG 4-11: Know methods for elicitation of functional requirements
 
 * Know that there are many different elicitation techniques that architects should be aware of, e.g. interviews, questionnaires, brainstorming sessions, three amigo sessions <<smart-amigo>>, knowledge crunching, event storming and many others
+* Know prototypes and mockups as an elicitation and validation technique, especially for UI/UX-related requirements: users often react more concretely to a visible artifact than to an abstract description <<snyder>>
 * Know when to pick which elicitation technique to improve communication with stakeholders
 
 

--- a/docs/99-references/00-references.adoc
+++ b/docs/99-references/00-references.adoc
@@ -27,6 +27,7 @@ This section contains references that are cited in the curriculum.
 **C**
 
 - [[[clegg,Clegg]]] Dai Clegg and Richard Barker (1994). Case Method Fast-Track: A RAD Approach. Addison-Wesley.
+- [[[cooper,Cooper]]] Cooper, Alan: The Inmates Are Running the Asylum: Why High-Tech Products Drive Us Crazy and How to Restore the Sanity. Sams, 1999.
 - [[[cucumber,Cucumber]]] Cucumber: BDD testing and executable specifications. https://cucumber.io/
 
 **D**
@@ -56,6 +57,10 @@ This section contains references that are cited in the curriculum.
 
 - [[[jacobson,Jacobson]]] Dr. Ivar Jacobson, Ian Spence, Kurt Bittner: Use-Case 2.0: The Guide to Succeeding with Use-Cases. Online: https://www.ivarjacobson.com/publications/white-papers/use-case-20-e-book
 - [[[jeffries-ccc,Jeffries]]] Jeffries, Ron: Essential XP: Card, Conversation, Confirmation, 2001. https://ronjeffries.com/xprog/articles/expcardconversationconfirmation/
+
+**K**
+
+- [[[kalbach,Kalbach]]] Kalbach, Jim: Mapping Experiences: A Complete Guide to Creating Value through Journeys, Blueprints, and Diagrams. O'Reilly, 2016.
 
 **L**
 
@@ -89,6 +94,7 @@ This section contains references that are cited in the curriculum.
 
 - [[[smart-bdd,Smart]]] Smart, J.F. / Molak, J.: BDD in Action: Behavior-Driven Development for the whole software lifecycle. Manning, 2nd edition 2023. https://www.manning.com/books/bdd-in-action-second-edition
 - [[[smart-amigo,Smart-Amigo]]] Smart, J.F.: The Anatomy of a Three Amigo requirements discovery Session. https://johnfergusonsmart.com/three-amigos-requirements-discovery/
+- [[[snyder,Snyder]]] Snyder, Carolyn: Paper Prototyping: The Fast and Easy Way to Design and Refine User Interfaces. Morgan Kaufmann, 2003.
 - [[[starke-hruschka-arc42,Starke-Hruschka]]] Starke,G + Hruschka, P: Communicating Software Architectures: lean, effective and painless documentation. Leanpub https://leanpub.com/arc42inpractice
 
 **T**


### PR DESCRIPTION
Closes #78.

Two mainstream elicitation/validation techniques were only name-checked previously; this promotes both to proper learning-goal content, per the issue's own proposal:

- **LZ/LG-4-11** (elicitation techniques, Ch4): new bullet naming prototypes/mockups as an elicitation and validation technique, especially for UI/UX-related requirements.
- **LZ/LG-3-4** (stakeholders, Ch3): new bullet naming personas and user-journey maps as artifacts for consolidating and visualizing stakeholder needs.
- **Terms and concepts** lists updated in both chapters to match.

No references existed for any of these three concepts, so three new bibliography entries were added:
- Snyder, *Paper Prototyping* (Morgan Kaufmann, 2003) — the classic prototyping/mockups reference
- Cooper, *The Inmates Are Running the Asylum* (Sams, 1999) — originating source for personas
- Kalbach, *Mapping Experiences* (O'Reilly, 2016) — journey mapping

Validated with both EN and DE asciidoctor builds (`--failure-level=WARN`).