### PR TITLE
Add business rules to LG 4-1 (#77)

### DIFF
--- a/docs/00a-preamble/preface-ireb.adoc
+++ b/docs/00a-preamble/preface-ireb.adoc
@@ -4,7 +4,7 @@
 :sectnum!:
 ## Vorwort
 
-IREB, das International Requirements Engineering Board, engagiert sich seit mehr als vierzehn Jahren für die Ausbildung von Fachleuten im Requirements Engineering. Bis 2020 haben mehr als fünfzigtausend Personen das Zertifikat CPRE FL (Certified Professional for Requirements Engineering – Foundation Level) erworben.
+IREB, das International Requirements Engineering Board, engagiert sich seit mehr als zwanzig Jahren für die Ausbildung von Fachleuten im Requirements Engineering. Bis 2026 haben mehr als hunderttausend Personen das Zertifikat CPRE FL (Certified Professional for Requirements Engineering – Foundation Level) erworben.
 
 Da weltweit mehr als fünf Millionen Menschen in der IT arbeiten, überrascht es nicht, dass es noch viele Entwicklungsteams gibt, die weder selbst über ausreichende Requirements-Engineering-Kenntnisse verfügen noch Zugang zu entsprechend ausgebildeten Spezialist:innen haben – obwohl sie sich bei der Entwicklung und Bereitstellung von Softwareprodukten mit Anforderungsfragen auseinandersetzen müssen.
 
@@ -15,7 +15,7 @@ Wir wünschen Ihnen viel Erfolg mit diesem Modul und mit Ihren ersten Schritten 
 
 [cols="3,7,7",header=none,frame=none,grid=none]
 |===
-|Januar 2020
+|August 2026
 a|Martin Glinz
 
 Vorsitzender des IREB Council
@@ -31,7 +31,7 @@ Vorsitzender des Executive Board von IREB
 [preface]
 == Preface
 
-IREB, the International Requirements Engineering Board, has been committed to educating professionals in requirements engineering for more than fourteen years. Up to 2020, more than fifty thousand people have acquired the CPRE FL certificate (Certified Professional for Requirements Engineering – Foundation Level).
+IREB, the International Requirements Engineering Board, has been committed to educating professionals in requirements engineering for more than twenty years. Up to 2026, more than hundred thousand people have acquired the CPRE FL certificate (Certified Professional for Requirements Engineering – Foundation Level).
 
 As there are more than five million people working in IT worldwide, it is not surprising that there are still many development teams who neither have sufficient requirements engineering skills themselves, nor have access to specialists trained in requirements engineering – although they have to deal with requirements issues when developing and deploying software products.
 
@@ -42,7 +42,7 @@ We wish you success with this module and with your first steps in requirements e
 
 [cols="3,7,7",header=none,frame=none,grid=none]
 |===
-|January 2020
+|August 2026
 a|Martin Glinz
 
 Chairman of the IREB Council

--- a/docs/04-Functional-Requirements/02-learning-goals.adoc
+++ b/docs/04-Functional-Requirements/02-learning-goals.adoc
@@ -6,6 +6,7 @@
 
 * Die Definition funktionaler Anforderungen kennen
 * Funktionale Anforderungen von Qualitätsanforderungen und Randbedingungen unterscheiden
+* Wissen, dass Geschäftsregeln (z.B. Berechnungen, Richtlinien, Einschränkungen von Daten) funktionale Anforderungen bestimmen, und dass ihre Auslagerung aus der Anwendungslogik architektonisch bedeutsam ist
 
 [[LZ-4-2]]
 ==== LZ 4-2: Hierarchien funktionaler Anforderungen
@@ -80,6 +81,7 @@ Verstehen, dass viele unterschiedliche Kriterien zur Zerlegung eines Systems in 
 
 * Know the definition of functional requirements
 * Distinguish functional requirements from quality requirements and constraints
+* Know that business rules (e.g. calculations, policies, constraints on data) drive functional requirements, and that externalising them from application logic is architecturally significant
 
 [[LG-4-2]]
 ==== LG 4-2: Hierarchies of functional requirements


### PR DESCRIPTION
Closes #77.

Business rules — a standard requirements category (Wiegers, BABOK), and often architecturally significant because they are frequently externalised/made configurable — were not mentioned anywhere in the curriculum.

## Change
Adds one bullet to **LG/LZ 4-1** (in both EN and DE) relating business rules to functional requirements and noting the architectural relevance of externalising rules from application logic:

> Know that business rules (e.g. calculations, policies, constraints on data) drive functional requirements, and that externalising them from application logic is architecturally significant

This is the lightweight "brief mention in Ch4" option from the issue proposal (P3). No new learning goal or glossary entry was added.
